### PR TITLE
Normalize feature calculations in rhyme analysis

### DIFF
--- a/module1_enhanced_core_phonetic.py
+++ b/module1_enhanced_core_phonetic.py
@@ -214,15 +214,19 @@ class EnhancedPhoneticAnalyzer:
         """Comprehensive analysis of rhyme pattern between two words"""
         similarity = self.get_phonetic_similarity(word1, word2)
         rhyme_type = self.classify_rhyme_type(word1, word2, similarity)
-        
+
+        # Normalize words once for feature calculations to ensure consistent scoring
+        clean_word1 = self._clean_word(word1)
+        clean_word2 = self._clean_word(word2)
+
         # Calculate detailed phonetic features
         features = {
-            'ending_similarity': self._calculate_ending_similarity(word1, word2),
-            'vowel_similarity': self._calculate_vowel_similarity(word1, word2),
-            'consonant_similarity': self._calculate_consonant_similarity(word1, word2),
-            'syllable_similarity': self._calculate_syllable_similarity(word1, word2)
+            'ending_similarity': self._calculate_ending_similarity(clean_word1, clean_word2),
+            'vowel_similarity': self._calculate_vowel_similarity(clean_word1, clean_word2),
+            'consonant_similarity': self._calculate_consonant_similarity(clean_word1, clean_word2),
+            'syllable_similarity': self._calculate_syllable_similarity(clean_word1, clean_word2)
         }
-        
+
         return PhoneticMatch(
             word1=word1,
             word2=word2,


### PR DESCRIPTION
## Summary
- normalize the word inputs once in `analyze_rhyme_pattern` before computing feature scores
- reuse the cleaned forms for ending, vowel, consonant, and syllable similarity calculations while preserving the reported words

## Testing
- python module1_enhanced_core_phonetic.py
- python - <<'PY'
from module1_enhanced_core_phonetic import EnhancedPhoneticAnalyzer

analyzer = EnhancedPhoneticAnalyzer()
baseline = analyzer.analyze_rhyme_pattern("Time", "Rhyme")
variant = analyzer.analyze_rhyme_pattern("Time!", "RHYME?!")
print("Baseline features:", baseline.phonetic_features)
print("Variant features:", variant.phonetic_features)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d1c0475ac88322b41661db98487249