### PR TITLE
Ensure engines share app database path

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,8 +41,8 @@ class RhymeRarityApp:
     def __init__(self, db_path: str = "patterns.db"):
         self.db_path = db_path
         self.phonetic_analyzer = EnhancedPhoneticAnalyzer()
-        self.anti_llm_engine = AntiLLMRhymeEngine()
-        self.cultural_engine = CulturalIntelligenceEngine()
+        self.anti_llm_engine = AntiLLMRhymeEngine(db_path=self.db_path)
+        self.cultural_engine = CulturalIntelligenceEngine(db_path=self.db_path)
         
         # Initialize database
         self.check_database()


### PR DESCRIPTION
## Summary
- update `RhymeRarityApp` so helper engines are constructed with the same database path as the app

## Testing
- `python - <<'PY'
import os
import sys
import types

gr = types.ModuleType("gradio")
pd = types.ModuleType("pandas")
sys.modules.setdefault("gradio", gr)
sys.modules.setdefault("pandas", pd)

from app import RhymeRarityApp

db_path = "temp_patterns.db"
if os.path.exists(db_path):
    os.remove(db_path)

app = RhymeRarityApp(db_path=db_path)

results = app.search_rhymes("love")
print(f"Rhymes found: {len(results)}")

anti_patterns = app.anti_llm_engine.generate_anti_llm_patterns("love", limit=5)
print(f"Anti-LLM patterns: {len(anti_patterns)}")

if results:
    context = app.cultural_engine.get_cultural_context(results[0])
    print("Cultural context sample:", context)

if os.path.exists(db_path):
    os.remove(db_path)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d1c0c8c11c832281fb7931786a1974