### PR TITLE
Refine UI layout and streamline formatted output

### DIFF
--- a/rhyme_rarity/app/services/search_service.py
+++ b/rhyme_rarity/app/services/search_service.py
@@ -1578,6 +1578,91 @@ class SearchService:
             except (TypeError, ValueError):
                 return None
 
+        def _format_phonetics_line(phonetics: Any) -> Optional[str]:
+            if not isinstance(phonetics, dict):
+                return None
+            parts: List[str] = []
+            syllables = phonetics.get("syllables")
+            if isinstance(syllables, (int, float)):
+                parts.append(f"Syllables: {int(syllables)}")
+            stress_display = phonetics.get("stress_pattern_display") or phonetics.get(
+                "stress_pattern"
+            )
+            if stress_display:
+                parts.append(f"Stress: {stress_display}")
+            meter_hint = phonetics.get("meter_hint")
+            foot = phonetics.get("metrical_foot")
+            if meter_hint:
+                parts.append(f"Meter: {meter_hint}")
+            elif foot:
+                parts.append(f"Meter: {str(foot).title()}")
+            if not parts:
+                return None
+            return f"Phonetics: {' | '.join(parts)}"
+
+        def _resolve_source_label(
+            source_key: str,
+            entry: Dict[str, Any],
+            parent: Optional[Dict[str, Any]] = None,
+        ) -> Optional[str]:
+            explicit_source = entry.get("result_source")
+            if explicit_source is None and parent is not None:
+                explicit_source = parent.get("result_source")
+            normalized_source = _normalize_source_key(explicit_source) or source_key
+            mapping = {
+                "cmu": "CMU Pronouncing Dictionary",
+                "anti_llm": "Anti-LLM Pattern Library",
+                "rap_db": "Rap & Cultural Archive",
+            }
+            if normalized_source in mapping:
+                return mapping[normalized_source]
+            if explicit_source:
+                return str(explicit_source)
+            return mapping.get(source_key, source_key.replace("_", " ").title())
+
+        def _standard_info_segments(
+            subject: Dict[str, Any],
+            source_key: str,
+            parent: Optional[Dict[str, Any]] = None,
+        ) -> List[str]:
+            segments: List[str] = []
+            rhyme_category = "Phrase" if subject.get("is_multi_word") else "Word"
+            segments.append(f"Rhyme Type: {rhyme_category}")
+
+            phonetics_line = _format_phonetics_line(subject.get("target_phonetics") or {})
+            if phonetics_line:
+                segments.append(phonetics_line)
+
+            rarity_value = subject.get("rarity_score")
+            if rarity_value is None:
+                rarity_value = subject.get("cultural_rarity")
+            if rarity_value is None and parent is not None:
+                rarity_value = parent.get("rarity_score") or parent.get("cultural_rarity")
+            rarity_formatted = _format_float(rarity_value)
+            if rarity_formatted:
+                segments.append(f"Rarity: {rarity_formatted}")
+
+            rhyme_label = _resolve_rhyme_type(subject) or (
+                _resolve_rhyme_type(parent) if parent is not None else None
+            )
+            if rhyme_label:
+                segments.append(f"Rhyme type: {rhyme_label}")
+
+            confidence_value = subject.get("combined_score")
+            if confidence_value is None:
+                confidence_value = subject.get("confidence")
+            if confidence_value is None and parent is not None:
+                confidence_value = parent.get("combined_score") or parent.get("confidence")
+            confidence_formatted = _format_float(confidence_value)
+            if confidence_formatted:
+                segments.append(f"Confidence: {confidence_formatted}")
+
+            source_label = _resolve_source_label(source_key, subject, parent)
+            if source_label:
+                segments.append(f"Source: {source_label}")
+
+            return [segment for segment in segments if segment]
+
         lines: List[str] = [
             f"🎯 **TARGET RHYMES for '{source_word.upper()}':**",
             "=" * 50,
@@ -1593,7 +1678,9 @@ class SearchService:
         syllables = source_phonetics.get("syllables")
         if isinstance(syllables, (int, float)):
             basic_parts.append(f"Syllables: {int(syllables)}")
-        stress_display = source_phonetics.get("stress_pattern_display") or source_phonetics.get("stress_pattern")
+        stress_display = source_phonetics.get("stress_pattern_display") or source_phonetics.get(
+            "stress_pattern"
+        )
         if stress_display:
             basic_parts.append(f"Stress: {stress_display}")
         meter_hint = source_phonetics.get("meter_hint")
@@ -1601,36 +1688,9 @@ class SearchService:
         if meter_hint:
             basic_parts.append(f"Meter: {meter_hint}")
         elif foot:
-            basic_parts.append(f"Foot: {str(foot).title()}")
+            basic_parts.append(f"Meter: {str(foot).title()}")
         if basic_parts:
             lines.append(f"   • Basic: {' | '.join(basic_parts)}")
-
-        signature_values = source_profile.get("signatures") or []
-        if signature_values:
-            lines.append(f"   • Signatures: {', '.join(signature_values)}")
-
-        similarity_parts: List[str] = []
-        reference_similarity = _format_float(source_profile.get("reference_similarity"))
-        threshold_value = _format_float(source_profile.get("threshold"))
-        if reference_similarity:
-            similarity_parts.append(f"Reference sim: {reference_similarity}")
-        if threshold_value:
-            similarity_parts.append(f"Threshold: {threshold_value}")
-        if similarity_parts:
-            lines.append(f"   • Similarity band: {' | '.join(similarity_parts)}")
-
-        expanded_parts: List[str] = []
-        vowel_skeleton = source_phonetics.get("vowel_skeleton")
-        if vowel_skeleton:
-            expanded_parts.append(f"Vowels: {vowel_skeleton}")
-        consonant_tail = source_phonetics.get("consonant_tail")
-        if consonant_tail:
-            expanded_parts.append(f"Tail: {consonant_tail}")
-        pronunciations = source_phonetics.get("pronunciations") or []
-        if pronunciations:
-            lines.append(f"   • Pronunciations: {', '.join(pronunciations)}")
-        if expanded_parts:
-            lines.append(f"   • Expanded: {' | '.join(expanded_parts)}")
         lines.append("")
 
         for key, header in category_order:
@@ -1647,266 +1707,133 @@ class SearchService:
                     if not targets:
                         continue
 
-                    artist_name = entry.get("artist") or "Unknown Artist"
-                    song_title = entry.get("song") or "Unknown Track"
-                    lines.append(f"• **{artist_name} — {song_title}**")
+                    artist = entry.get("artist")
+                    song = entry.get("song")
+                    if artist and song:
+                        artist_segment = f"{artist} — {song}"
+                    elif artist:
+                        artist_segment = str(artist)
+                    elif song:
+                        artist_segment = str(song)
+                    else:
+                        artist_segment = None
 
-                    meta_bits: List[str] = []
+                    genre_bits: List[str] = []
                     genre_value = entry.get("genre")
                     if genre_value:
-                        meta_bits.append(f"Genre: {genre_value}")
-                    cultural_sig = entry.get("cultural_sig")
-                    if cultural_sig:
-                        meta_bits.append(
-                            f"Significance: {str(cultural_sig).replace('_', ' ').title()}"
-                        )
+                        genre_bits.append(f"Genre: {genre_value}")
                     group_size = entry.get("group_size")
                     if group_size:
-                        meta_bits.append(f"Targets: {int(group_size)}")
-                    if meta_bits:
-                        lines.append(f"   • {' | '.join(meta_bits)}")
-
-                    group_scores: List[str] = []
-                    top_confidence = _format_float(entry.get("max_confidence") or entry.get("confidence"))
-                    if top_confidence:
-                        group_scores.append(f"Top confidence: {top_confidence}")
-                    top_similarity = _format_float(entry.get("max_phonetic_sim") or entry.get("phonetic_sim"))
-                    if top_similarity:
-                        group_scores.append(f"Top similarity: {top_similarity}")
-                    if group_scores:
-                        lines.append(f"   • {' | '.join(group_scores)}")
-
-                    context_info = _as_dict(entry.get("cultural_context"))
-                    cultural_bits: List[str] = []
-                    style_line: Optional[str] = None
-                    for key_name, label in (
-                        ("era", "Era"),
-                        ("regional_origin", "Region"),
-                        ("cultural_significance", "Significance"),
-                    ):
-                        value = context_info.get(key_name)
-                        if not value and key_name == "cultural_significance":
-                            value = entry.get("cultural_sig")
-                        if value:
-                            cultural_bits.append(f"{label}: {str(value).replace('_', ' ').title()}")
-                    styles = context_info.get("style_characteristics")
-                    if isinstance(styles, (list, tuple)) and styles:
-                        formatted_styles = ", ".join(
-                            str(style).replace('_', ' ').title() for style in styles if style
-                        )
-                        if formatted_styles:
-                            style_line = formatted_styles
-                    if cultural_bits:
-                        lines.append(f"   • Cultural: {' | '.join(cultural_bits)}")
-                    if style_line:
-                        lines.append(f"   • Styles: {style_line}")
+                        try:
+                            genre_bits.append(f"Targets: {int(group_size)}")
+                        except (TypeError, ValueError):
+                            genre_bits.append(f"Targets: {group_size}")
 
                     for target in targets:
-                        target_word = target.get("target_word") or "(unknown)"
-                        variant_note = " (phrase)" if target.get("is_multi_word") else ""
-                        lines.append(f"   • **{str(target_word).upper()}**{variant_note}")
+                        pattern_text = target.get("pattern") or target.get("target_word") or "(unknown)"
+                        subject_label = f"Pattern: {pattern_text}"
 
-                        target_phonetics = target.get("target_phonetics") or {}
-                        phonetic_bits: List[str] = []
-                        target_syllables = target_phonetics.get("syllables")
-                        if isinstance(target_syllables, (int, float)):
-                            phonetic_bits.append(f"Syllables: {int(target_syllables)}")
-                        target_stress = target_phonetics.get("stress_pattern_display") or target_phonetics.get("stress_pattern")
-                        if target_stress:
-                            phonetic_bits.append(f"Stress: {target_stress}")
-                        target_meter = target_phonetics.get("meter_hint")
-                        target_foot = target_phonetics.get("metrical_foot")
-                        if target_meter:
-                            phonetic_bits.append(f"Meter: {target_meter}")
-                        elif target_foot:
-                            phonetic_bits.append(f"Foot: {str(target_foot).title()}")
-                        syllable_span = target.get("syllable_span")
-                        if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
-                            try:
-                                phonetic_bits.append(
-                                    f"Span: {int(syllable_span[0])}→{int(syllable_span[1])}"
+                        line_segments = [subject_label]
+                        line_segments.extend(
+                            _standard_info_segments(target, key, parent=entry)
+                        )
+
+                        metadata_segments: List[str] = []
+                        if artist_segment:
+                            metadata_segments.append(artist_segment)
+                        if genre_bits:
+                            metadata_segments.append(" | ".join(genre_bits))
+
+                        hidden_segments: List[str] = []
+                        context_info = _as_dict(entry.get("cultural_context"))
+                        cultural_bits: List[str] = []
+                        for key_name, label in (
+                            ("era", "Era"),
+                            ("regional_origin", "Region"),
+                            ("cultural_significance", "Significance"),
+                        ):
+                            value = context_info.get(key_name)
+                            if not value and key_name == "cultural_significance":
+                                value = entry.get("cultural_sig")
+                            if value:
+                                cultural_bits.append(
+                                    f"{label}: {str(value).replace('_', ' ').title()}"
                                 )
-                            except Exception:
-                                pass
-                        if phonetic_bits:
-                            lines.append(f"      • Phonetics: {' | '.join(phonetic_bits)}")
+                        if cultural_bits:
+                            hidden_segments.append(
+                                f"<!-- • Cultural: {' | '.join(cultural_bits)} -->"
+                            )
 
-                        pronunciation_variants = target_phonetics.get("pronunciations") or []
-                        if pronunciation_variants:
-                            lines.append(f"      • Phonemes: {', '.join(pronunciation_variants)}")
+                        styles = context_info.get("style_characteristics")
+                        if isinstance(styles, (list, tuple)) and styles:
+                            formatted_styles = ", ".join(
+                                str(style).replace("_", " ").title() for style in styles if style
+                            )
+                            if formatted_styles:
+                                hidden_segments.append(
+                                    f"<!-- • Styles: {formatted_styles} -->"
+                                )
 
-                        score_parts: List[str] = []
-                        similarity_value = _format_float(target.get("phonetic_sim"))
-                        if similarity_value:
-                            score_parts.append(f"Similarity: {similarity_value}")
-                        confidence_value = target.get("combined_score")
-                        if confidence_value is None:
-                            confidence_value = target.get("confidence")
-                        confidence_formatted = _format_float(confidence_value)
-                        if confidence_formatted:
-                            score_parts.append(f"Confidence: {confidence_formatted}")
-                        rarity_value = target.get("rarity_score")
-                        if rarity_value is None:
-                            rarity_value = target.get("cultural_rarity")
-                        rarity_formatted = _format_float(rarity_value)
-                        if rarity_formatted:
-                            score_parts.append(f"Rarity: {rarity_formatted}")
-                        if score_parts:
-                            lines.append(f"      • Scores: {' | '.join(score_parts)}")
-
-                        rhyme_label = _resolve_rhyme_type(target)
-                        if rhyme_label:
-                            lines.append(f"      • Rhyme type: {rhyme_label}")
-
-                        pattern_text = target.get("pattern")
-                        if pattern_text:
-                            lines.append(f"      • Pattern: {pattern_text}")
-
-                        source_context = target.get("source_context")
-                        target_context = target.get("target_context")
                         context_parts: List[str] = []
-                        if source_context:
-                            context_parts.append(str(source_context))
-                        if target_context:
-                            context_parts.append(str(target_context))
+                        for value in (
+                            target.get("source_context"),
+                            target.get("target_context"),
+                        ):
+                            if value:
+                                context_parts.append(str(value))
                         if context_parts:
-                            lines.append(f"      • Context: {' | '.join(context_parts)}")
+                            metadata_segments.append(f"Context: {' | '.join(context_parts)}")
+
+                        if metadata_segments:
+                            line_segments.extend(metadata_segments)
 
                         prosody = target.get("prosody_profile")
                         if isinstance(prosody, dict):
                             cadence = prosody.get("complexity_tag")
                             if cadence:
-                                lines.append(
-                                    f"      • Cadence: {str(cadence).replace('_', ' ').title()}"
+                                hidden_segments.append(
+                                    f"<!-- • Cadence: {str(cadence).replace('_', ' ').title()} -->"
                                 )
 
-                    lines.append("")
+                        if hidden_segments:
+                            line_segments.extend(hidden_segments)
+
+                        formatted_line = " • ".join(
+                            segment for segment in line_segments if segment
+                        )
+                        if formatted_line:
+                            lines.append(formatted_line)
+                            lines.append("")
 
                 lines.append("")
                 continue
 
             for entry in entries:
                 target_word = entry.get("target_word") or "(unknown)"
-                variant_note = " (phrase)" if entry.get("is_multi_word") else ""
-                lines.append(f"• **{str(target_word).upper()}**{variant_note}")
+                subject_label = f"**{str(target_word).upper()}**"
 
-                target_phonetics = entry.get("target_phonetics") or {}
-                phonetic_bits: List[str] = []
-                target_syllables = target_phonetics.get("syllables")
-                if isinstance(target_syllables, (int, float)):
-                    phonetic_bits.append(f"Syllables: {int(target_syllables)}")
-                target_stress = target_phonetics.get("stress_pattern_display") or target_phonetics.get("stress_pattern")
-                if target_stress:
-                    phonetic_bits.append(f"Stress: {target_stress}")
-                target_meter = target_phonetics.get("meter_hint")
-                target_foot = target_phonetics.get("metrical_foot")
-                if target_meter:
-                    phonetic_bits.append(f"Meter: {target_meter}")
-                elif target_foot:
-                    phonetic_bits.append(f"Foot: {str(target_foot).title()}")
-                syllable_span = entry.get("syllable_span")
-                if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
-                    try:
-                        phonetic_bits.append(f"Span: {int(syllable_span[0])}→{int(syllable_span[1])}")
-                    except Exception:
-                        pass
-                if phonetic_bits:
-                    lines.append(f"   • Phonetics: {' | '.join(phonetic_bits)}")
+                line_segments = [subject_label]
+                line_segments.extend(_standard_info_segments(entry, key))
 
-                pronunciation_variants = target_phonetics.get("pronunciations") or []
-                if pronunciation_variants:
-                    lines.append(f"   • Phonemes: {', '.join(pronunciation_variants)}")
-
-                score_parts = []
-                similarity_value = _format_float(entry.get("phonetic_sim"))
-                if similarity_value:
-                    score_parts.append(f"Similarity: {similarity_value}")
-                confidence_value = entry.get("combined_score")
-                if confidence_value is None:
-                    confidence_value = entry.get("confidence")
-                confidence_formatted = _format_float(confidence_value)
-                if confidence_formatted:
-                    score_parts.append(f"Confidence: {confidence_formatted}")
-                rarity_value = entry.get("rarity_score")
-                if rarity_value is None:
-                    rarity_value = entry.get("cultural_rarity")
-                rarity_formatted = _format_float(rarity_value)
-                if rarity_formatted:
-                    score_parts.append(f"Rarity: {rarity_formatted}")
-                if score_parts:
-                    lines.append(f"   • Scores: {' | '.join(score_parts)}")
-
-                rhyme_label = _resolve_rhyme_type(entry)
-                if rhyme_label:
-                    lines.append(f"   • Rhyme type: {rhyme_label}")
-
-                normalized_source = _normalize_source_key(entry.get("result_source")) or key
-                if normalized_source == "cmu":
-                    lines.append("   • Source: CMU Pronouncing Dictionary")
-                elif normalized_source == "anti_llm":
+                if key == "anti_llm":
+                    hidden_segments: List[str] = []
                     weakness = entry.get("llm_weakness_type")
                     if weakness:
-                        lines.append(f"   • LLM weakness: {str(weakness).replace('_', ' ').title()}")
+                        hidden_segments.append(
+                            f"<!-- • LLM weakness: {str(weakness).replace('_', ' ').title()} -->"
+                        )
                     cultural_depth = entry.get("cultural_depth")
                     if cultural_depth:
-                        lines.append(f"   • Cultural depth: {cultural_depth}")
-                else:
-                    credits: List[str] = []
-                    artist = entry.get("artist")
-                    song = entry.get("song")
-                    if artist:
-                        credits.append(str(artist))
-                    if song:
-                        credits.append(str(song))
-                    if credits:
-                        lines.append(f"   • Credits: {' — '.join(credits)}")
-                    genre_value = entry.get("genre")
-                    if genre_value:
-                        lines.append(f"   • Genre: {genre_value}")
-
-                    context_info = _as_dict(entry.get("cultural_context"))
-                    cultural_bits = []
-                    for key_name, label in (
-                        ("era", "Era"),
-                        ("regional_origin", "Region"),
-                        ("cultural_significance", "Significance"),
-                    ):
-                        value = context_info.get(key_name)
-                        if not value and key_name == "cultural_significance":
-                            value = entry.get("cultural_sig")
-                        if value:
-                            cultural_bits.append(f"{label}: {str(value).replace('_', ' ').title()}")
-                    if cultural_bits:
-                        lines.append(f"   • Cultural: {' | '.join(cultural_bits)}")
-                    styles = context_info.get("style_characteristics")
-                    if isinstance(styles, (list, tuple)) and styles:
-                        formatted_styles = ", ".join(
-                            str(style).replace('_', ' ').title() for style in styles if style
+                        hidden_segments.append(
+                            f"<!-- • Cultural depth: {cultural_depth} -->"
                         )
-                        if formatted_styles:
-                            lines.append(f"   • Styles: {formatted_styles}")
+                    if hidden_segments:
+                        line_segments.extend(hidden_segments)
 
-                pattern_text = entry.get("pattern")
-                if pattern_text:
-                    lines.append(f"   • Pattern: {pattern_text}")
-
-                source_context = entry.get("source_context")
-                target_context = entry.get("target_context")
-                context_parts: List[str] = []
-                if source_context:
-                    context_parts.append(str(source_context))
-                if target_context:
-                    context_parts.append(str(target_context))
-                if context_parts:
-                    lines.append(f"   • Context: {' | '.join(context_parts)}")
-
-                prosody = entry.get("prosody_profile")
-                if isinstance(prosody, dict):
-                    cadence = prosody.get("complexity_tag")
-                    if cadence:
-                        lines.append(f"   • Cadence: {str(cadence).replace('_', ' ').title()}")
-
-                lines.append("")
+                formatted_line = " • ".join(segment for segment in line_segments if segment)
+                if formatted_line:
+                    lines.append(formatted_line)
+                    lines.append("")
 
             lines.append("")
 

--- a/rhyme_rarity/app/ui/gradio.py
+++ b/rhyme_rarity/app/ui/gradio.py
@@ -72,10 +72,11 @@ def create_interface(
     .rr-hero {text-align: center; padding-bottom: 16px;}
     .rr-hero h2 {font-size: 2.1rem; margin-bottom: 0.25rem;}
     .rr-hero p {color: #4b5563; font-size: 1rem;}
-    .rr-main-row {gap: 24px; align-items: stretch;}
     .rr-panel {border: 1px solid rgba(15, 23, 42, 0.08); border-radius: 16px; background: #ffffff; padding: 24px; box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);}
     .rr-panel h3 {margin-top: 0; font-weight: 700; letter-spacing: 0.02em;}
+    .rr-section {width: 100%;}
     .rr-input-panel .gr-form {gap: 16px;}
+    .rr-search-panel {width: 100%;}
     .rr-button {width: 100%; font-weight: 600;}
     .rr-tip {color: #4b5563; font-size: 0.92rem; margin-top: 8px;}
     .rr-results-panel {display: flex; flex-direction: column; gap: 16px; min-height: 420px;}
@@ -95,83 +96,82 @@ def create_interface(
                 elem_classes=["rr-hero"],
             )
 
-            with gr.Row(equal_height=True, elem_classes=["rr-main-row"]):
-                with gr.Column(scale=5, min_width=360):
-                    with gr.Group(elem_classes=["rr-panel", "rr-input-panel"]):
-                        gr.Markdown("### Search settings")
-                        word_input = gr.Textbox(
-                            label="Word to Find Rhymes For",
-                            placeholder="Enter a word (e.g., love, mind, flow, money)",
-                            lines=1,
-                        )
+            with gr.Column(elem_classes=["rr-section"]):
+                with gr.Group(elem_classes=["rr-panel", "rr-input-panel", "rr-search-panel"]):
+                    gr.Markdown("### Search settings")
+                    word_input = gr.Textbox(
+                        label="Word to Find Rhymes For",
+                        placeholder="Enter a word (e.g., love, mind, flow, money)",
+                        lines=1,
+                    )
 
-                        with gr.Accordion(
-                            "Advanced filters",
-                            open=False,
-                            elem_classes=["rr-accordion"],
-                        ):
-                            with gr.Row():
-                                max_results = gr.Slider(
-                                    minimum=5,
-                                    maximum=50,
-                                    value=15,
-                                    step=1,
-                                    label="Max Results",
+                    with gr.Accordion(
+                        "Advanced filters",
+                        open=False,
+                        elem_classes=["rr-accordion"],
+                    ):
+                        with gr.Row():
+                            max_results = gr.Slider(
+                                minimum=5,
+                                maximum=50,
+                                value=15,
+                                step=1,
+                                label="Max Results",
+                            )
+
+                            min_confidence = gr.Slider(
+                                minimum=0.5,
+                                maximum=1.0,
+                                value=0.7,
+                                step=0.05,
+                                label="Min Confidence",
+                            )
+
+                        with gr.Row():
+                            with gr.Column(scale=1, min_width=160):
+                                cultural_dropdown = gr.Dropdown(
+                                    choices=cultural_options,
+                                    multiselect=True,
+                                    label="Cultural Significance",
+                                    info="Highlight results by their cultural weight",
+                                    value=[],
                                 )
 
-                                min_confidence = gr.Slider(
-                                    minimum=0.5,
-                                    maximum=1.0,
-                                    value=0.7,
-                                    step=0.05,
-                                    label="Min Confidence",
+                                genre_dropdown = gr.Dropdown(
+                                    choices=genre_options,
+                                    multiselect=True,
+                                    label="Genre",
+                                    info="Limit to specific genres",
+                                    value=[],
                                 )
 
-                            with gr.Row():
-                                with gr.Column(scale=1, min_width=160):
-                                    cultural_dropdown = gr.Dropdown(
-                                        choices=cultural_options,
-                                        multiselect=True,
-                                        label="Cultural Significance",
-                                        info="Highlight results by their cultural weight",
-                                        value=[],
-                                    )
+                            with gr.Column(scale=1, min_width=160):
+                                rhyme_type_dropdown = gr.Dropdown(
+                                    choices=["perfect", "near", "slant", "eye", "weak"],
+                                    multiselect=True,
+                                    label="Rhyme Type",
+                                    info="Limit to specific rhyme categories",
+                                    value=[],
+                                )
 
-                                    genre_dropdown = gr.Dropdown(
-                                        choices=genre_options,
-                                        multiselect=True,
-                                        label="Genre",
-                                        info="Limit to specific genres",
-                                        value=[],
-                                    )
+                    search_btn = gr.Button(
+                        "🔍 Find Rhymes",
+                        variant="primary",
+                        size="lg",
+                        elem_classes=["rr-button"],
+                    )
+                    gr.Markdown(
+                        "💡 Enter a word, tune the filters, and click **Find Rhymes** to surface uncommon pairings.",
+                        elem_classes=["rr-tip"],
+                    )
 
-                                with gr.Column(scale=1, min_width=160):
-                                    rhyme_type_dropdown = gr.Dropdown(
-                                        choices=["perfect", "near", "slant", "eye", "weak"],
-                                        multiselect=True,
-                                        label="Rhyme Type",
-                                        info="Limit to specific rhyme categories",
-                                        value=[],
-                                    )
-
-                        search_btn = gr.Button(
-                            "🔍 Find Rhymes",
-                            variant="primary",
-                            size="lg",
-                            elem_classes=["rr-button"],
-                        )
-                        gr.Markdown(
-                            "💡 Enter a word, tune the filters, and click **Find Rhymes** to surface uncommon pairings.",
-                            elem_classes=["rr-tip"],
-                        )
-
-                with gr.Column(scale=5, min_width=360):
-                    with gr.Group(elem_classes=["rr-panel", "rr-results-panel"]):
-                        gr.Markdown("### Rhyme results")
-                        output = gr.Markdown(
-                            value="Start by entering a word on the left and click **Find Rhymes**.",
-                            elem_classes=["rr-results-markdown"],
-                        )
+            with gr.Column(elem_classes=["rr-section"]):
+                with gr.Group(elem_classes=["rr-panel", "rr-results-panel"]):
+                    gr.Markdown("### Rhyme results")
+                    output = gr.Markdown(
+                        value="Start by entering a word on the left and click **Find Rhymes**.",
+                        elem_classes=["rr-results-markdown"],
+                    )
 
         search_btn.click(
             fn=search_interface,


### PR DESCRIPTION
## Summary
- Let the search controls span the first row and move the results panel to its own full-width row with refreshed styling
- Simplify the source profile text and standardise rhyme result lines across CMU, anti-LLM, and rap sections with consistent ordering and metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d350c299ec8322a8ca29d4061414b6