### PR TITLE
Add dummy analyzer fixture for attach profile tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from anti_llm import AntiLLMRhymeEngine
+
+
+class DummyProfileAnalyzer:
+    """Analyzer stub that returns deterministic profile data."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def derive_rhyme_profile(self, source: str, target: str):
+        self.calls.append((source, target))
+        return {
+            "bradley_device": "slant",
+            "syllable_span": (1, 3),
+            "stress_alignment": 0.75,
+            "assonance_score": 0.5,
+            "consonance_score": 0.25,
+            "internal_rhyme_score": 0.4,
+        }
+
+
+@pytest.fixture
+def engine_with_dummy_analyzer():
+    """Engine instance that uses the dummy analyzer for profile generation."""
+
+    analyzer = DummyProfileAnalyzer()
+    engine = AntiLLMRhymeEngine(phonetic_analyzer=analyzer)
+    return engine

--- a/tests/test_anti_llm_engine.py
+++ b/tests/test_anti_llm_engine.py
@@ -7,7 +7,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from anti_llm import AntiLLMRhymeEngine, SeedCandidate
+from anti_llm import AntiLLMPattern, AntiLLMRhymeEngine, SeedCandidate
 from anti_llm.strategies import find_cultural_depth_patterns
 from rhyme_rarity.app.data.database import SQLiteRhymeRepository
 
@@ -129,3 +129,30 @@ def test_cultural_depth_strategy_returns_patterns(tmp_path):
 
     assert patterns
     assert any("[mainstream]" in pattern.cultural_depth for pattern in patterns)
+
+def test_attach_profile_populates_prosody_fields(engine_with_dummy_analyzer):
+    engine = engine_with_dummy_analyzer
+    analyzer = engine.phonetic_analyzer
+
+    pattern = AntiLLMPattern(
+        source_word="Shadow",
+        target_word="Meadow",
+        rarity_score=1.0,
+        cultural_depth="[test]",
+        llm_weakness_type="prosody",
+        confidence=0.8,
+    )
+
+    engine._attach_profile(pattern)
+
+    assert analyzer.calls == [("Shadow", "Meadow")]
+    assert pattern.bradley_device == "slant"
+    assert pattern.syllable_span == (1, 3)
+    assert pattern.stress_alignment == pytest.approx(0.75)
+    assert pattern.feature_profile["assonance_score"] == pytest.approx(0.5)
+    assert pattern.feature_profile["consonance_score"] == pytest.approx(0.25)
+
+    assert pattern.prosody_profile["complexity_tag"] == "dense"
+    assert pattern.prosody_profile["stress_alignment"] == pytest.approx(0.75)
+    assert pattern.prosody_profile["assonance"] == pytest.approx(0.5)
+    assert pattern.prosody_profile["consonance"] == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- add a pytest fixture that instantiates `AntiLLMRhymeEngine` with a deterministic dummy analyzer
- add a regression test ensuring `_attach_profile` populates stress alignment, syllable span, and prosody details from the analyzer profile

## Testing
- pytest tests/test_anti_llm_engine.py -k prosody

------
https://chatgpt.com/codex/tasks/task_e_68d3c26b30648322b047ac4bb1bb913c