### PR TITLE
Add competitor analysis playbook and CLI probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,12 @@ Running the tests ensures the fallback database creation and rhyme search behave
 - Cultural significance filters blend values stored in your database with curated category descriptions (e.g., `classic`, `cultural-icon`, `underground`) so the dropdown always reflects available metadata. The anti-LLM cultural-depth queries automatically detect whichever `cultural_significance` labels exist in the database, allowing you to introduce custom taxonomies without code changes.
 - `app.py` contains helper methods such as `format_rhyme_results` and `search_rhymes` that you can import into other projects or wrap with alternative front-ends.
 
+## Competitive research playbook
+
+Use the materials under `docs/competitor_analysis/` when auditing competitor
+sites such as RhymeZone or B-Rhymes. The playbook explains how to capture UI
+behaviour, network payloads, and parity notes, while the templates and
+`scripts/feature_probe.py` helper make it easy to mirror competitor filters
+against the existing search service.
+
 Happy rhyming!

--- a/docs/competitor_analysis/README.md
+++ b/docs/competitor_analysis/README.md
@@ -1,0 +1,158 @@
+# Competitor Functionality Audit Playbook
+
+This playbook operationalises the research plan for benchmarking RhymeRarity against
+popular rhyme dictionaries including **RhymeZone**, **Double-Rhyme**, **B-Rhymes**
+and **Rhymes.com**. It breaks the process into repeatable stages so any contributor
+can observe how competitors behave, capture the findings in structured notes, and
+map the results onto the existing codebase.
+
+---
+
+## 1. Establish your research workspace
+
+1. Clone this repository or pull the latest changes.
+2. Create a working folder under `docs/competitor_analysis/records/` for the audit
+   run you are about to perform, e.g. `docs/competitor_analysis/records/2024-09-15/`.
+3. Copy the templates from `docs/competitor_analysis/templates/` into that folder.
+   They contain the note-taking scaffolding referenced below.
+4. Decide which browsers and devices you will test on (desktop and mobile layouts
+   can expose different feature sets).
+5. Prepare a list of seed prompts (single words, multi-word phrases, rare or slang
+   terms) to exercise each site. The `seed_prompts` table inside the
+   `site_audit_template.md` template includes a starting point.
+
+---
+
+## 2. Catalogue functionality per competitor site
+
+For each target site repeat the following subsections. The `site_audit_template.md`
+file has placeholders that mirror the headings below so you can log the data as
+you go.
+
+### 2.1 Manual feature discovery
+- Run all prepared seed prompts and add new prompts when the interface suggests
+  alternative searches.
+- Record how queries are entered (single text box, advanced forms, filters).
+- Note the result groupings (perfect vs. near rhymes, multi-syllabic groupings,
+  popularity rankings, links to definitions or lyrics).
+- Capture any extra utilities surfaced on the page (copy/share buttons, export
+  options, audio pronunciation, usage examples, vocabulary helpers).
+
+### 2.2 UI controls and states
+- List every toggle, dropdown, slider, or accordion you interact with.
+- Document default values versus user-adjustable ranges.
+- Take screenshots when a state change reveals extra functionality (e.g., tabs
+  for synonyms vs. antonyms, filters that appear only on hover).
+- Pay attention to onboarding hints and contextual explanations that clarify how
+the site expects users to interpret the results.
+
+### 2.3 Network and data inspection
+- Open the browser developer tools (Network tab) before submitting a query.
+- Observe XHR/Fetch requests triggered during a search. Log endpoints, query
+  parameters, and response payload types (HTML, JSON, XML).
+- Save notable responses into the `network_observations` table (mask or omit any
+  personally identifiable information if you have an account).
+- If the responses are JSON, record field names that imply backend capabilities
+  (e.g., `syllables`, `score`, `popularity_rank`, `rhyme_type`).
+- Inspect any embedded scripts for inline configuration data that might list
+  supported filters or thresholds.
+
+### 2.4 Content provenance and guidance
+- Check for FAQ, help, or documentation links that describe how the service
+  computes rhymes or defines categories.
+- Record references to external datasets, textbooks, or linguistic models.
+- Note subscription tiers or gated features so the backlog can reflect whether
+  parity requires authentication.
+
+---
+
+## 3. Build a cross-site comparison matrix
+
+1. Consolidate the per-site notes into `comparison_matrix_template.md`.
+2. Populate the table columns covering rhyme categorisation, filter controls,
+   metadata enrichment, educational aides, and monetisation hooks.
+3. Highlight differentiating behaviours using the "Key observations" column so
+   stakeholders can quickly identify unique selling points.
+4. Add supporting screenshots or request payload samples within collapsible
+   sections to keep the matrix compact while retaining evidence.
+
+---
+
+## 4. Map findings onto RhymeRarity
+
+Use the "RhymeRarity linkage" section of the comparison matrix to indicate how
+existing modules relate to each capability:
+
+- **Phonetic analysis** → `rhyme_rarity/core/module1_enhanced_core_phonetic.py`
+  and the `EnhancedPhoneticAnalyzer` referenced by
+  `rhyme_rarity/app/services/search_service.py`.
+- **Anti-LLM rarity heuristics** → `anti_llm/module2_enhanced_anti_llm.py` and
+  the way `SearchService.search_rhymes` aggregates results from
+  `AntiLLMRhymeEngine`.
+- **Cultural context** → `cultural/module3_enhanced_cultural_database.py` and the
+  `CulturalIntelligenceEngine` filters in the search service.
+- **UI workflows** → `rhyme_rarity/app/ui/gradio.py` for existing controls,
+  plus any additional widgets that might be required to match competitor flows.
+
+Whenever a competitor feature is already present in RhymeRarity, specify which
+functions or endpoints exercise it (e.g., `SearchService.search_rhymes` supports
+`allowed_rhyme_types`, `cultural_significance`, and `genres`). If a capability is
+missing, note the gap and draft a backlog item in the "Follow-up actions" list in
+your record folder.
+
+---
+
+## 5. Verify existing functionality
+
+After mapping features, execute the following to confirm parity:
+
+1. Run exploratory searches through the Gradio UI launched via `python app.py`.
+   Mirror the competitor prompts and document whether filters behave as expected.
+2. Use the CLI helper `scripts/feature_probe.py` (described below) to exercise
+   service-level queries with specific filters and to capture machine-readable
+   output for regression purposes.
+3. Add or update automated tests under `tests/` when you discover features that
+   should be locked down (e.g., verifying syllable filters or cultural matching).
+4. Record evidence (screenshots, CLI logs) in your record folder so future audits
+   can reuse the groundwork.
+
+---
+
+## 6. Regression and backlog management
+
+- **Regression tracking**: Store the filled templates in git so historical audits
+  remain reviewable. Create follow-up issues summarising gaps discovered during
+  the comparison.
+- **Data refresh**: When adding new datasets to mirror competitor breadth,
+  document schema changes or import scripts alongside the audit notes.
+- **Release validation**: Re-run the comparison when major features land or when
+  competitor sites roll out visible changes.
+
+---
+
+## 7. Tooling reference
+
+### CLI probe
+`scripts/feature_probe.py` wraps the `RhymeRarityApp` so you can quickly verify
+search filters without launching the UI. Example:
+
+```bash
+python scripts/feature_probe.py "love" \
+  --limit 25 \
+  --min-confidence 0.6 \
+  --cultural golden-era underground \
+  --genres hip-hop \
+  --rhyme-types perfect near \
+  --sources phonetic cultural
+```
+
+Run `python scripts/feature_probe.py --help` for the full option list.
+
+### Templates
+- `site_audit_template.md`: one per competitor site.
+- `comparison_matrix_template.md`: roll-up table that compares sites.
+- `verification_checklist.md`: keeps track of verification status once features
+  are implemented or confirmed.
+
+Keep this playbook updated as the research process evolves so future auditors can
+follow consistent steps.

--- a/docs/competitor_analysis/templates/comparison_matrix_template.md
+++ b/docs/competitor_analysis/templates/comparison_matrix_template.md
@@ -1,0 +1,25 @@
+# Competitor Comparison Matrix
+
+| Capability | RhymeZone | Double-Rhyme | B-Rhymes | Rhymes.com | RhymeRarity linkage | Key observations |
+| --- | --- | --- | --- | --- | --- | --- |
+| Search input modes |  |  |  |  |  |  |
+| Rhyme categorisation |  |  |  |  |  |  |
+| Multi-syllabic support |  |  |  |  |  |  |
+| Filter controls |  |  |  |  |  |  |
+| Metadata / annotations |  |  |  |  |  |  |
+| Educational aides |  |  |  |  |  |  |
+| Export / sharing |  |  |  |  |  |  |
+| Account-only features |  |  |  |  |  |  |
+| Monetisation |  |  |  |  |  |  |
+| Mobile layout differences |  |  |  |  |  |  |
+| Accessibility notes |  |  |  |  |  |  |
+| Performance notes |  |  |  |  |  |  |
+| Follow-up backlog items |  |  |  |  |  |  |
+
+## Supporting evidence
+- Link to per-site audit notes.
+- Embed screenshots or payload samples using collapsible sections if needed.
+
+## Summary narrative
+Synthesize the competitive positioning, calling out where RhymeRarity already matches
+or exceeds functionality and where new work is required.

--- a/docs/competitor_analysis/templates/site_audit_template.md
+++ b/docs/competitor_analysis/templates/site_audit_template.md
@@ -1,0 +1,82 @@
+# {SITE_NAME} — Feature Audit
+
+## Metadata
+- **Auditor**: {YOUR_NAME}
+- **Date**: {YYYY-MM-DD}
+- **Device(s) tested**: {e.g., Desktop Chrome 126, iPhone Safari}
+- **Account status**: {Guest / Logged in / Subscription tier}
+
+---
+
+## Seed prompts exercised
+| Prompt | Purpose | Notes |
+| --- | --- | --- |
+| love | Baseline common word |  |
+| time | Compare with love |  |
+| money | Stress multi-syllable results |  |
+| inner peace | Phrase handling |  |
+| {add more} |  |  |
+
+---
+
+## Feature discovery log
+| Timestamp | Action | Observation |
+| --- | --- | --- |
+| 12:03 | Submitted "love" | Returned groups: perfect rhymes, near rhymes, synonyms |
+| 12:06 | Opened advanced filters | Revealed syllable range slider |
+| {..} |  |  |
+
+---
+
+## Result structure
+- **Primary groupings**: {perfect, near, phrases, ...}
+- **Sorting cues**: {alphabetical, popularity, score, ...}
+- **Metadata fields**: {syllables, stress pattern, definitions, usage examples, ...}
+- **Export/share tools**: {copy, print, permalink, API, ...}
+
+---
+
+## UI controls
+| Control | Type | Default | Range / Options | Behaviour |
+| --- | --- | --- | --- | --- |
+| Advanced filters accordion | Accordion | Closed | N/A | Reveals syllable + rhyme type filters |
+| Syllable slider | Slider | 1-4 | 1-8 | Filters results instantly |
+| {..} |  |  |  |  |
+
+---
+
+## Network observations
+| Request URL | Trigger | Notable parameters | Response format | Notes |
+| --- | --- | --- | --- | --- |
+| https://example.com/rhyme?word=love | Search submit | word, syllables | JSON | Contains `syllables`, `frequency` |
+| {..} |  |  |  |  |
+
+Use this space for prettified payload samples:
+```json
+{
+  "word": "love",
+  "matches": [
+    {"term": "dove", "score": 0.92, "syllables": 1}
+  ]
+}
+```
+
+---
+
+## Content provenance
+- **Help / FAQ references**: {links}
+- **Mentioned datasets or corpora**: {description}
+- **Educational aides**: {explanations, definitions, videos}
+- **Monetisation hooks**: {ads, premium upsell, donations}
+
+---
+
+## Standout behaviours
+- Itemise unique or surprising capabilities that RhymeRarity should emulate or deliberately differentiate from.
+
+---
+
+## Follow-up actions
+- [ ] {Task 1}
+- [ ] {Task 2}
+- [ ] Add backlog issue linking to this audit

--- a/docs/competitor_analysis/templates/verification_checklist.md
+++ b/docs/competitor_analysis/templates/verification_checklist.md
@@ -1,0 +1,21 @@
+# Verification Checklist
+
+Use this checklist after completing the comparison matrix to confirm which features
+exist today and where work remains.
+
+## Parity validation
+- [ ] Gradio UI exposes equivalent filters (cultural, genre, rhyme type).
+- [ ] CLI probe reproduces competitor query patterns.
+- [ ] `SearchService.search_rhymes` returns grouped results with combined scores.
+- [ ] Cultural engine surfaces expected metadata (`cultural_significance`, `genres`).
+- [ ] Anti-LLM engine supplies rarity metrics for advanced patterns.
+- [ ] Database schema supports required metadata fields.
+- [ ] Automated tests cover each verified capability.
+
+## Gaps & backlog
+| Capability gap | Suggested owner | Priority | Notes |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## Evidence log
+Link to CLI outputs, screenshots, or test runs that demonstrate verification.

--- a/scripts/feature_probe.py
+++ b/scripts/feature_probe.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""CLI helper to exercise RhymeRarity search features for competitive analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List, Optional, Sequence
+
+from rhyme_rarity.app.app import RhymeRarityApp
+
+
+def _parse_list(values: Optional[Sequence[str]]) -> List[str]:
+    """Normalize CLI list arguments.
+
+    Supports comma-separated strings so auditors can pass values as
+    ``--cultural golden-era,underground`` or as separate tokens.
+    """
+
+    if not values:
+        return []
+
+    items: List[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            parts = [part.strip() for part in value.split(",")]
+            items.extend(part for part in parts if part)
+        else:
+            items.append(str(value))
+    return items
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Probe the RhymeRarity search stack with configurable filters to "
+            "mirror competitor behaviour."
+        )
+    )
+    parser.add_argument("word", help="Source word or phrase to analyse.")
+    parser.add_argument(
+        "--database",
+        default="patterns.db",
+        help="Path to the SQLite database (defaults to patterns.db).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of results to request from each source.",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.7,
+        help="Minimum confidence threshold applied to all sources.",
+    )
+    parser.add_argument(
+        "--cultural",
+        nargs="*",
+        metavar="LABEL",
+        help="Cultural significance labels (space or comma separated).",
+    )
+    parser.add_argument(
+        "--genres",
+        nargs="*",
+        metavar="GENRE",
+        help="Genre filters (space or comma separated).",
+    )
+    parser.add_argument(
+        "--rhyme-types",
+        nargs="*",
+        metavar="TYPE",
+        help="Allowed rhyme types (e.g., perfect, near, slant).",
+    )
+    parser.add_argument(
+        "--bradley",
+        nargs="*",
+        metavar="DEVICE",
+        help="Limit by Bradley rhyme device categories.",
+    )
+    parser.add_argument(
+        "--sources",
+        nargs="*",
+        metavar="SOURCE",
+        help=(
+            "Restrict result sources (phonetic, cultural, anti-llm). "
+            "Defaults to all sources when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--max-line-distance",
+        type=int,
+        help="Filter cultural matches by maximum line distance.",
+    )
+    parser.add_argument(
+        "--min-syllables",
+        type=int,
+        help="Minimum syllable span for rhyme candidates.",
+    )
+    parser.add_argument(
+        "--max-syllables",
+        type=int,
+        help="Maximum syllable span for rhyme candidates.",
+    )
+    parser.add_argument(
+        "--require-internal",
+        action="store_true",
+        help="Require internal rhyme matches when supported by data.",
+    )
+    parser.add_argument(
+        "--min-rarity",
+        type=float,
+        help="Minimum rarity score (anti-LLM engine).",
+    )
+    parser.add_argument(
+        "--min-stress",
+        type=float,
+        help="Minimum stress alignment score.",
+    )
+    parser.add_argument(
+        "--cadence-focus",
+        help="Target cadence focus label (e.g., swing, triplet).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of formatted text (good for logging).",
+    )
+    parser.add_argument(
+        "--pretty-json",
+        action="store_true",
+        help="Indent JSON output for readability (implies --json).",
+    )
+    parser.add_argument(
+        "--show-params",
+        action="store_true",
+        help="Print the resolved parameter set before executing the search.",
+    )
+    return parser
+
+
+def _resolve_params(namespace: argparse.Namespace) -> dict:
+    """Translate CLI arguments to `SearchService.search_rhymes` keyword args."""
+
+    params = {
+        "source_word": namespace.word,
+        "limit": namespace.limit,
+        "min_confidence": namespace.min_confidence,
+        "cultural_significance": _parse_list(namespace.cultural),
+        "genres": _parse_list(namespace.genres),
+        "allowed_rhyme_types": _parse_list(namespace.rhyme_types),
+        "bradley_devices": _parse_list(namespace.bradley),
+        "result_sources": _parse_list(namespace.sources),
+        "max_line_distance": namespace.max_line_distance,
+        "min_syllables": namespace.min_syllables,
+        "max_syllables": namespace.max_syllables,
+        "require_internal": namespace.require_internal,
+        "min_rarity": namespace.min_rarity,
+        "min_stress_alignment": namespace.min_stress,
+        "cadence_focus": namespace.cadence_focus,
+    }
+
+    cleaned: dict = {}
+    for key, value in params.items():
+        if value in (None, [], {}):
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    params = _resolve_params(args)
+
+    if args.show_params:
+        print("Resolved parameters:")
+        print(json.dumps(params, indent=2, sort_keys=True))
+        print()
+
+    app = RhymeRarityApp(db_path=args.database)
+    results = app.search_rhymes(**params)
+
+    if args.pretty_json or args.json:
+        indent = 2 if args.pretty_json else None
+        json.dump(results, sys.stdout, indent=indent, ensure_ascii=False, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+
+    formatted = app.format_rhyme_results(args.word, results)
+    print(formatted)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document a repeatable competitive research workflow in `docs/competitor_analysis/README.md`
- add note-taking templates for per-site audits, comparison matrices, and verification checklists
- provide a `scripts/feature_probe.py` CLI to exercise search filters from the terminal and reference it in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c3bc87bc8322a1221290e6d1e7e5