### PR TITLE
Add memoization layers across phonetic search stack

### DIFF
--- a/rhyme_rarity/core/__init__.py
+++ b/rhyme_rarity/core/__init__.py
@@ -11,6 +11,7 @@ from .feature_profile import (
     PhoneticMatch,
     PhraseComponents,
     RhymeFeatureProfile,
+    clear_phrase_component_cache,
     extract_phrase_components,
 )
 from .rarity_map import DEFAULT_RARITY_MAP, WordRarityMap
@@ -25,6 +26,7 @@ __all__ = [
     "PhraseComponents",
     "PhoneticMatch",
     "extract_phrase_components",
+    "clear_phrase_component_cache",
     "get_cmu_rhymes",
     "RARITY_SIMILARITY_WEIGHT",
     "RARITY_NOVELTY_WEIGHT",


### PR DESCRIPTION
## Summary
- memoize expensive phrase component extraction and expose a cache reset hook
- layer analyzer, search-service, and CMU result caches to reuse phonetic computations per request
- cache cultural signature derivation so repeated lookups reuse analyzer output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c60b40ac83229835d0272f4a7aae