### PR TITLE
Add structured observability across search pipeline

### DIFF
--- a/cultural/engine.py
+++ b/cultural/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from typing import Any, Dict, List, Optional, Set
 
@@ -27,6 +28,9 @@ from .profiles import (
     generate_dynamic_profile,
 )
 
+
+logger = logging.getLogger(__name__)
+
 class CulturalIntelligenceEngine:
     """
     Enhanced cultural intelligence system providing authentic attribution
@@ -51,8 +55,14 @@ class CulturalIntelligenceEngine:
             'regional_patterns_identified': 0
         }
         
-        print("🎯 Enhanced Cultural Database Engine initialized")
-        print("Providing authentic cultural attribution beyond LLM capabilities")
+        logger.info(
+            "cultural_engine.initialized",
+            extra={
+                "db_path": db_path,
+                "profiles": len(self.artist_profiles),
+                "categories": len(self.cultural_categories),
+            },
+        )
  
     def set_phonetic_analyzer(self, analyzer: Any) -> None:
         """Attach or replace the phonetic analyzer for phonetic validation."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pronouncing>=0.2.0,<0.3
 
 # Local quality gates
 pytest>=7.0.0,<9.0
+

--- a/rhyme_rarity/app/services/search_service.py
+++ b/rhyme_rarity/app/services/search_service.py
@@ -2,20 +2,32 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set, Tuple
+import json
+import logging
 import re
 import types
+from collections import OrderedDict
+from time import perf_counter
+from typing import Any, Dict, List, Optional, Set, Tuple
 
+from anti_llm import AntiLLMRhymeEngine
+from cultural.engine import CulturalIntelligenceEngine
 from rhyme_rarity.core import (
     EnhancedPhoneticAnalyzer,
     extract_phrase_components,
     get_cmu_rhymes,
 )
-from anti_llm import AntiLLMRhymeEngine
-from cultural.engine import CulturalIntelligenceEngine
+from rhyme_rarity.utils.observability import (
+    observe_stage_latency,
+    record_search_error,
+    record_search_request,
+    update_cache_hit_ratio,
+)
 
 from ..data.database import SQLiteRhymeRepository
+
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -45,6 +57,11 @@ class SearchService:
             Tuple[str, int, Optional[int], Optional[int]], Tuple[Any, ...]
         ] = OrderedDict()
         self._related_words_cache: OrderedDict[Tuple[str, ...], Tuple[str, ...]] = OrderedDict()
+        self._cache_stats = {
+            "fallback_signature": {"hits": 0, "lookups": 0},
+            "cmu_rhyme": {"hits": 0, "lookups": 0},
+            "related_words": {"hits": 0, "lookups": 0},
+        }
 
     def set_phonetic_analyzer(self, analyzer: Optional[EnhancedPhoneticAnalyzer]) -> None:
         self.phonetic_analyzer = analyzer
@@ -68,6 +85,10 @@ class SearchService:
         self._fallback_signature_cache.clear()
         self._cmu_rhyme_cache.clear()
         self._related_words_cache.clear()
+        for stats in self._cache_stats.values():
+            stats["hits"] = 0
+            stats["lookups"] = 0
+        logger.info("cache.cleared", extra={"caches": list(self._cache_stats.keys())})
 
     def _reset_phonetic_caches(self) -> None:
         """Drop caches derived from analyzer or CMU resources."""
@@ -75,20 +96,41 @@ class SearchService:
         self._cmu_rhyme_cache.clear()
         self._related_words_cache.clear()
 
-    def _trim_cache(self, cache: OrderedDict[Any, Tuple[Any, ...]]) -> None:
+    def _trim_cache(self, cache: OrderedDict[Any, Tuple[Any, ...]], name: str) -> None:
         """Ensure caches stay within the configured ``_max_cache_entries`` size."""
 
         if self._max_cache_entries <= 0:
             return
 
         while len(cache) > self._max_cache_entries:
-            cache.popitem(last=False)
+            evicted_key, _ = cache.popitem(last=False)
+            logger.debug(
+                "cache.trim",
+                extra={"cache": name, "evicted": repr(evicted_key), "size": len(cache)},
+            )
+
+    def _record_cache_lookup(self, cache_name: str, hit: bool) -> None:
+        stats = self._cache_stats.setdefault(cache_name, {"hits": 0, "lookups": 0})
+        stats["lookups"] += 1
+        if hit:
+            stats["hits"] += 1
+        update_cache_hit_ratio(cache_name, stats["hits"], stats["lookups"])
+        logger.debug(
+            "cache.lookup",
+            extra={
+                "cache": cache_name,
+                "hit": hit,
+                "hits": stats["hits"],
+                "lookups": stats["lookups"],
+            },
+        )
 
     def _fallback_signature(self, word: Optional[str]) -> Set[str]:
         """Compute a light-weight fallback signature with memoization."""
 
         cache_key = (word or "").strip().lower()
         cached = self._fallback_signature_cache.get(cache_key)
+        self._record_cache_lookup("fallback_signature", cached is not None)
         if cached is not None:
             self._fallback_signature_cache.move_to_end(cache_key)
             return set(cached)
@@ -107,7 +149,7 @@ class SearchService:
             signature_tuple = ("|".join(signature_bits),)
 
         self._fallback_signature_cache[cache_key] = signature_tuple
-        self._trim_cache(self._fallback_signature_cache)
+        self._trim_cache(self._fallback_signature_cache, "fallback_signature")
 
         return set(signature_tuple)
 
@@ -127,22 +169,49 @@ class SearchService:
             id(cmu_loader) if cmu_loader is not None else None,
         )
         cached = self._cmu_rhyme_cache.get(cache_key)
+        self._record_cache_lookup("cmu_rhyme", cached is not None)
         if cached is not None:
             self._cmu_rhyme_cache.move_to_end(cache_key)
+            logger.debug(
+                "cache.hit",
+                extra={
+                    "cache": "cmu_rhyme",
+                    "source_word": source_word,
+                    "limit": limit,
+                },
+            )
             return list(cached)
 
-        try:
-            results = get_cmu_rhymes(
-                source_word,
-                limit=limit,
-                analyzer=analyzer,
-                cmu_loader=cmu_loader,
-            )
-        except Exception:
-            results = []
+        with observe_stage_latency(
+            "cmu_lookup",
+            span_name="search.cmu_lookup",
+            source_word=source_word,
+            limit=limit,
+        ):
+            try:
+                results = get_cmu_rhymes(
+                    source_word,
+                    limit=limit,
+                    analyzer=analyzer,
+                    cmu_loader=cmu_loader,
+                )
+            except Exception:
+                record_search_error(
+                    "cmu",
+                    source_word=source_word,
+                    limit=limit,
+                )
+                logger.exception(
+                    "cmu.lookup_failed",
+                    extra={
+                        "source_word": source_word,
+                        "limit": limit,
+                    },
+                )
+                results = []
 
         self._cmu_rhyme_cache[cache_key] = tuple(results)
-        self._trim_cache(self._cmu_rhyme_cache)
+        self._trim_cache(self._cmu_rhyme_cache, "cmu_rhyme")
 
         return list(results)
 
@@ -159,18 +228,39 @@ class SearchService:
             return set()
 
         cached = self._related_words_cache.get(normalized_terms)
+        self._record_cache_lookup("related_words", cached is not None)
         if cached is not None:
             self._related_words_cache.move_to_end(normalized_terms)
+            logger.debug(
+                "cache.hit",
+                extra={
+                    "cache": "related_words",
+                    "terms": list(normalized_terms),
+                },
+            )
             return set(cached)
 
-        try:
-            results = self.repository.fetch_related_words(set(normalized_terms))
-        except Exception:
-            results = set()
+        with observe_stage_latency(
+            "repository_lookup",
+            span_name="search.repository_related",
+            term_count=len(normalized_terms),
+        ):
+            try:
+                results = self.repository.fetch_related_words(set(normalized_terms))
+            except Exception:
+                record_search_error(
+                    "repository",
+                    terms=list(normalized_terms),
+                )
+                logger.exception(
+                    "repository.related_lookup_failed",
+                    extra={"terms": list(normalized_terms)},
+                )
+                results = set()
 
         results_set = set(results)
         self._related_words_cache[normalized_terms] = tuple(sorted(results_set))
-        self._trim_cache(self._related_words_cache)
+        self._trim_cache(self._related_words_cache, "related_words")
 
         return results_set
 
@@ -206,7 +296,12 @@ class SearchService:
             def _empty_response() -> Dict[str, List[Dict]]:
                 return {"cmu": [], "anti_llm": [], "rap_db": []}
 
-            if not source_word or not source_word.strip():
+            raw_source_word = source_word
+            if not source_word or not str(source_word).strip():
+                logger.warning(
+                    "search.empty_request",
+                    extra={"source_word": raw_source_word},
+                )
                 return _empty_response()
 
             source_word = source_word.lower().strip()
@@ -321,651 +416,485 @@ class SearchService:
             )
 
             if limit <= 0:
+                logger.warning(
+                    "search.invalid_limit",
+                    extra={"source_word": source_word, "limit": limit},
+                )
                 return _empty_response()
 
-            analyzer = getattr(self, "phonetic_analyzer", None)
-            cultural_engine = getattr(self, "cultural_engine", None)
-            cmu_loader = None
-            if analyzer is not None:
-                cmu_loader = getattr(analyzer, "cmu_loader", None)
-            if cmu_loader is None:
-                cmu_loader = getattr(self, "cmu_loader", None)
+            selected_sources_list = sorted(selected_sources)
+            request_context = {
+                "source_word": source_word,
+                "limit": int(limit),
+                "filters_active": filters_active,
+                "selected_sources": selected_sources_list,
+                "cultural_filters": sorted(cultural_filters),
+                "genre_filters": sorted(genre_filters),
+                "rhyme_types": sorted(rhyme_type_filters),
+                "bradley_devices": sorted(bradley_filters),
+                "cadence_focus": cadence_focus_normalized,
+                "require_internal": bool(require_internal),
+                "min_confidence": min_confidence,
+                "min_rarity": min_rarity_threshold,
+                "min_stress_alignment": min_stress_threshold,
+                "min_syllables": min_syllable_threshold,
+                "max_syllables": max_syllable_threshold,
+            }
+            logger.info("search.request %s", json.dumps(request_context, sort_keys=True))
 
-            source_components = extract_phrase_components(source_word, cmu_loader)
-            source_anchor_word = source_components.anchor or source_word
+            if include_phonetic:
+                record_search_request("phonetic", filters_active)
+            if include_cultural:
+                record_search_request("cultural", filters_active)
+            if include_anti_llm:
+                record_search_request("anti_llm", filters_active)
 
-            def _build_word_phonetics(word: Optional[str]) -> Dict[str, Any]:
-                base_word = "" if word is None else str(word)
-                defaults: Dict[str, Any] = {
-                    "word": base_word,
-                    "normalized": base_word.lower().strip(),
-                    "syllables": None,
-                    "stress_pattern": "",
-                    "stress_pattern_display": "",
-                    "meter_hint": None,
-                    "metrical_foot": None,
-                    "vowel_skeleton": "",
-                    "consonant_tail": "",
-                    "pronunciations": [],
-                    "tokens": [],
-                    "token_syllables": [],
-                    "anchor_word": "",
-                    "anchor_display": "",
-                    "is_multi_word": False,
-                }
-
-                if analyzer and hasattr(analyzer, "describe_word"):
-                    try:
-                        description = analyzer.describe_word(base_word)
-                    except Exception:
-                        description = None
-                    if description:
-                        if isinstance(description, dict):
-                            for key in defaults:
-                                if key in description and description[key] not in (None, ""):
-                                    defaults[key] = description[key]
-                        else:
-                            try:
-                                desc_dict = dict(description)
-                            except Exception:
-                                desc_dict = {}
-                            for key in defaults:
-                                if key in desc_dict and desc_dict[key] not in (None, ""):
-                                    defaults[key] = desc_dict[key]
-
-                if not defaults.get("tokens") and defaults.get("normalized"):
-                    defaults["tokens"] = defaults["normalized"].split()
-
-                if not defaults.get("anchor_word") and defaults.get("tokens"):
-                    defaults["anchor_word"] = defaults["tokens"][-1].lower()
-
-                if not defaults.get("anchor_display") and defaults.get("tokens"):
-                    defaults["anchor_display"] = defaults["tokens"][-1]
-
-                defaults["is_multi_word"] = bool(
-                    defaults.get("tokens") and len(defaults["tokens"]) > 1
-                )
-                if not defaults["is_multi_word"] and isinstance(defaults.get("normalized"), str):
-                    defaults["is_multi_word"] = " " in defaults["normalized"]
-
-                if defaults["syllables"] is None:
-                    estimate_fn = getattr(analyzer, "estimate_syllables", None)
-                    try:
-                        if callable(estimate_fn):
-                            defaults["syllables"] = estimate_fn(base_word)
-                    except Exception:
-                        defaults["syllables"] = None
-
-                stress_pattern = defaults.get("stress_pattern")
-                if stress_pattern and not defaults.get("stress_pattern_display"):
-                    defaults["stress_pattern_display"] = "-".join(str(ch) for ch in str(stress_pattern))
-
-                if not defaults.get("pronunciations"):
-                    pronunciations: List[str] = []
-                    if analyzer and hasattr(analyzer, "_get_pronunciation_variants"):
-                        try:
-                            variants = analyzer._get_pronunciation_variants(base_word)
-                        except Exception:
-                            variants = []
-                        for phones in variants[:2]:
-                            try:
-                                stripped = " ".join(analyzer._strip_stress_markers(phones))
-                            except Exception:
-                                stripped = ""
-                            if stripped:
-                                pronunciations.append(stripped)
-                    defaults["pronunciations"] = pronunciations
-
-                return defaults
-
-            def _sanitize_feature_profile(entry: Dict[str, Any]) -> Dict[str, Any]:
-                profile_obj = entry.get("feature_profile")
-                if profile_obj is None:
-                    profile_dict: Dict[str, Any] = {}
-                elif isinstance(profile_obj, dict):
-                    profile_dict = dict(profile_obj)
-                elif hasattr(profile_obj, "__dict__"):
-                    try:
-                        profile_dict = dict(vars(profile_obj))
-                    except Exception:
-                        profile_dict = {}
-                else:
-                    try:
-                        profile_dict = dict(profile_obj)
-                    except Exception:
-                        profile_dict = {}
-
-                bradley_value = None
-                if "bradley_device" in profile_dict:
-                    bradley_value = profile_dict.get("bradley_device")
-                    profile_dict.pop("bradley_device", None)
-                if entry.get("bradley_device") is not None and bradley_value is None:
-                    bradley_value = entry.get("bradley_device")
-
-                for banned_key in ("assonance_score", "consonance_score"):
-                    if banned_key in profile_dict:
-                        profile_dict.pop(banned_key, None)
-
-                if bradley_value is not None:
-                    entry["_bradley_device"] = bradley_value
-
-                entry["feature_profile"] = profile_dict
-                entry.pop("bradley_device", None)
-                entry.pop("assonance_score", None)
-                entry.pop("consonance_score", None)
-                return profile_dict
-
-            def _ensure_target_phonetics(entry: Dict[str, Any]) -> Dict[str, Any]:
-                target_profile = entry.get("target_phonetics")
-                if isinstance(target_profile, dict):
-                    return target_profile
-                target_word = entry.get("target_word")
-                profile = _build_word_phonetics(target_word)
-                entry["target_phonetics"] = profile
-                return profile
-
-            fallback_signature = self._fallback_signature
-
-            # Build the source word signature set using progressively simpler
-            # strategies so that downstream comparisons always have at least a
-            # minimal representation to work with.
-            source_signature_set: Set[str] = set()
-            if cultural_engine and hasattr(cultural_engine, "derive_rhyme_signatures"):
-                try:
-                    derived_signatures = cultural_engine.derive_rhyme_signatures(source_word)
-                    source_signature_set = {sig for sig in derived_signatures if sig}
-                except Exception:
-                    source_signature_set = set()
-            if not source_signature_set and cmu_loader is not None and source_anchor_word:
-                try:
-                    source_signature_set = {
-                        sig for sig in cmu_loader.get_rhyme_parts(source_anchor_word) if sig
-                    }
-                except Exception:
-                    source_signature_set = set()
-            if not source_signature_set:
-                source_signature_set = fallback_signature(source_anchor_word or source_word)
-
-            source_signature_list = sorted(source_signature_set)
-
-            # Fetch more CMU candidates than requested results so that scoring
-            # filters can discard low-quality matches without leaving the
-            # response empty.
-            reference_limit = max(limit * 2, 10)
-            cmu_candidates = self._lookup_cmu_rhymes(
-                source_word,
-                reference_limit,
-                analyzer,
-                cmu_loader,
+            total_timer = observe_stage_latency(
+                "search_total",
+                span_name="search.rhyme",
+                source_word=source_word,
+                filters_active=filters_active,
+                selected_sources=",".join(selected_sources_list),
             )
+            total_span = total_timer.__enter__()
+            start_time = perf_counter()
+            try:
+                analyzer = getattr(self, "phonetic_analyzer", None)
+                cultural_engine = getattr(self, "cultural_engine", None)
+                cmu_loader = None
+                if analyzer is not None:
+                    cmu_loader = getattr(analyzer, "cmu_loader", None)
+                if cmu_loader is None:
+                    cmu_loader = getattr(self, "cmu_loader", None)
 
-            reference_similarity = 0.0
-            for candidate in cmu_candidates:
-                if isinstance(candidate, dict):
-                    try:
-                        score = float(candidate.get("similarity", candidate.get("score", 0.0)))
-                    except (TypeError, ValueError):
-                        continue
-                else:
-                    try:
-                        score = float(candidate[1]) if len(candidate) > 1 else 0.0
-                    except (TypeError, ValueError, IndexError):
-                        score = 0.0
-                if score > reference_similarity:
-                    reference_similarity = score
+                source_components = extract_phrase_components(source_word, cmu_loader)
+                source_anchor_word = source_components.anchor or source_word
 
-            db_candidate_words: Set[str] = set()
-            if analyzer and self.repository:
-                lookup_terms = {source_word}
-                if source_anchor_word and source_anchor_word != source_word:
-                    lookup_terms.add(source_anchor_word)
-                db_candidate_words = self._fetch_related_words_cached(lookup_terms)
+                def _build_word_phonetics(word: Optional[str]) -> Dict[str, Any]:
+                    base_word = "" if word is None else str(word)
+                    defaults: Dict[str, Any] = {
+                        "word": base_word,
+                        "normalized": base_word.lower().strip(),
+                        "syllables": None,
+                        "stress_pattern": "",
+                        "stress_pattern_display": "",
+                        "meter_hint": None,
+                        "metrical_foot": None,
+                        "vowel_skeleton": "",
+                        "consonant_tail": "",
+                        "pronunciations": [],
+                        "tokens": [],
+                        "token_syllables": [],
+                        "anchor_word": "",
+                        "anchor_display": "",
+                        "is_multi_word": False,
+                    }
 
-                for candidate_word in db_candidate_words:
-                    if not candidate_word or candidate_word == source_word:
-                        continue
+                    if analyzer and hasattr(analyzer, "describe_word"):
+                        try:
+                            description = analyzer.describe_word(base_word)
+                        except Exception:
+                            description = None
+                        if description:
+                            if isinstance(description, dict):
+                                for key in defaults:
+                                    if key in description and description[key] not in (None, ""):
+                                        defaults[key] = description[key]
+                            else:
+                                try:
+                                    desc_dict = dict(description)
+                                except Exception:
+                                    desc_dict = {}
+                                for key in defaults:
+                                    if key in desc_dict and desc_dict[key] not in (None, ""):
+                                        defaults[key] = desc_dict[key]
+
+                    if not defaults.get("tokens") and defaults.get("normalized"):
+                        defaults["tokens"] = defaults["normalized"].split()
+
+                    if not defaults.get("anchor_word") and defaults.get("tokens"):
+                        defaults["anchor_word"] = defaults["tokens"][-1].lower()
+
+                    if not defaults.get("anchor_display") and defaults.get("tokens"):
+                        defaults["anchor_display"] = defaults["tokens"][-1]
+
+                    defaults["is_multi_word"] = bool(
+                        defaults.get("tokens") and len(defaults["tokens"]) > 1
+                    )
+                    if not defaults["is_multi_word"] and isinstance(defaults.get("normalized"), str):
+                        defaults["is_multi_word"] = " " in defaults["normalized"]
+
+                    if defaults["syllables"] is None:
+                        estimate_fn = getattr(analyzer, "estimate_syllables", None)
+                        try:
+                            if callable(estimate_fn):
+                                defaults["syllables"] = estimate_fn(base_word)
+                        except Exception:
+                            defaults["syllables"] = None
+
+                    stress_pattern = defaults.get("stress_pattern")
+                    if stress_pattern and not defaults.get("stress_pattern_display"):
+                        defaults["stress_pattern_display"] = "-".join(str(ch) for ch in str(stress_pattern))
+
+                    if not defaults.get("pronunciations"):
+                        pronunciations: List[str] = []
+                        if analyzer and hasattr(analyzer, "_get_pronunciation_variants"):
+                            try:
+                                variants = analyzer._get_pronunciation_variants(base_word)
+                            except Exception:
+                                variants = []
+                            for phones in variants[:2]:
+                                try:
+                                    stripped = " ".join(analyzer._strip_stress_markers(phones))
+                                except Exception:
+                                    stripped = ""
+                                if stripped:
+                                    pronunciations.append(stripped)
+                        defaults["pronunciations"] = pronunciations
+
+                    return defaults
+
+                def _sanitize_feature_profile(entry: Dict[str, Any]) -> Dict[str, Any]:
+                    profile_obj = entry.get("feature_profile")
+                    if profile_obj is None:
+                        profile_dict: Dict[str, Any] = {}
+                    elif isinstance(profile_obj, dict):
+                        profile_dict = dict(profile_obj)
+                    elif hasattr(profile_obj, "__dict__"):
+                        try:
+                            profile_dict = dict(vars(profile_obj))
+                        except Exception:
+                            profile_dict = {}
+                    else:
+                        try:
+                            profile_dict = dict(profile_obj)
+                        except Exception:
+                            profile_dict = {}
+
+                    bradley_value = None
+                    if "bradley_device" in profile_dict:
+                        bradley_value = profile_dict.get("bradley_device")
+                        profile_dict.pop("bradley_device", None)
+                    if entry.get("bradley_device") is not None and bradley_value is None:
+                        bradley_value = entry.get("bradley_device")
+
+                    for banned_key in ("assonance_score", "consonance_score"):
+                        if banned_key in profile_dict:
+                            profile_dict.pop(banned_key, None)
+
+                    if bradley_value is not None:
+                        entry["_bradley_device"] = bradley_value
+
+                    entry["feature_profile"] = profile_dict
+                    entry.pop("bradley_device", None)
+                    entry.pop("assonance_score", None)
+                    entry.pop("consonance_score", None)
+                    return profile_dict
+
+                def _ensure_target_phonetics(entry: Dict[str, Any]) -> Dict[str, Any]:
+                    target_profile = entry.get("target_phonetics")
+                    if isinstance(target_profile, dict):
+                        return target_profile
+                    target_word = entry.get("target_word")
+                    profile = _build_word_phonetics(target_word)
+                    entry["target_phonetics"] = profile
+                    return profile
+
+                fallback_signature = self._fallback_signature
+
+                # Build the source word signature set using progressively simpler
+                # strategies so that downstream comparisons always have at least a
+                # minimal representation to work with.
+                source_signature_set: Set[str] = set()
+                if cultural_engine and hasattr(cultural_engine, "derive_rhyme_signatures"):
                     try:
-                        score = float(analyzer.get_phonetic_similarity(source_word, candidate_word))
+                        derived_signatures = cultural_engine.derive_rhyme_signatures(source_word)
+                        source_signature_set = {sig for sig in derived_signatures if sig}
                     except Exception:
-                        continue
+                        source_signature_set = set()
+                if not source_signature_set and cmu_loader is not None and source_anchor_word:
+                    try:
+                        source_signature_set = {
+                            sig for sig in cmu_loader.get_rhyme_parts(source_anchor_word) if sig
+                        }
+                    except Exception:
+                        source_signature_set = set()
+                if not source_signature_set:
+                    source_signature_set = fallback_signature(source_anchor_word or source_word)
+
+                source_signature_list = sorted(source_signature_set)
+
+                # Fetch more CMU candidates than requested results so that scoring
+                # filters can discard low-quality matches without leaving the
+                # response empty.
+                reference_limit = max(limit * 2, 10)
+                cmu_candidates = self._lookup_cmu_rhymes(
+                    source_word,
+                    reference_limit,
+                    analyzer,
+                    cmu_loader,
+                )
+
+                reference_similarity = 0.0
+                for candidate in cmu_candidates:
+                    if isinstance(candidate, dict):
+                        try:
+                            score = float(candidate.get("similarity", candidate.get("score", 0.0)))
+                        except (TypeError, ValueError):
+                            continue
+                    else:
+                        try:
+                            score = float(candidate[1]) if len(candidate) > 1 else 0.0
+                        except (TypeError, ValueError, IndexError):
+                            score = 0.0
                     if score > reference_similarity:
                         reference_similarity = score
 
-            phonetic_threshold = 0.7
-            if reference_similarity > 0:
-                phonetic_threshold = max(0.6, min(0.92, reference_similarity - 0.1))
+                db_candidate_words: Set[str] = set()
+                if analyzer and self.repository:
+                    lookup_terms = {source_word}
+                    if source_anchor_word and source_anchor_word != source_word:
+                        lookup_terms.add(source_anchor_word)
+                    db_candidate_words = self._fetch_related_words_cached(lookup_terms)
 
-            source_phonetics = _build_word_phonetics(source_word)
-
-            prefix_tokens = []
-            suffix_tokens = []
-            if source_components.anchor_index is not None:
-                prefix_tokens = source_components.normalized_tokens[: source_components.anchor_index]
-                suffix_tokens = source_components.normalized_tokens[source_components.anchor_index + 1 :]
-
-            source_phonetic_profile = {
-                "word": source_word,
-                "threshold": phonetic_threshold,
-                "reference_similarity": reference_similarity,
-                "signatures": source_signature_list,
-                "phonetics": source_phonetics,
-                "anchor_word": source_anchor_word,
-                "anchor_display": source_components.anchor_display or source_anchor_word,
-                "phrase_tokens": source_components.normalized_tokens,
-                "phrase_prefix": " ".join(prefix_tokens).strip(),
-                "phrase_suffix": " ".join(suffix_tokens).strip(),
-                "token_syllables": source_components.syllable_counts,
-                "is_multi_word": bool(source_phonetics.get("is_multi_word")),
-            }
-
-            phonetic_entries: List[Dict] = []
-            module1_seed_payload: List[Dict] = []
-            aggregated_seed_signatures: Set[str] = set(source_signature_set)
-            delivered_words_set: Set[str] = set()
-            if include_phonetic:
-                slice_limit = reference_limit if reference_limit else max(limit, 1)
-                phonetic_matches = cmu_candidates[:slice_limit]
-                rarity_source = analyzer if analyzer is not None else getattr(self, "phonetic_analyzer", None)
-                for candidate in phonetic_matches:
-                    is_multi_variant = False
-                    variant_candidate: Optional[str] = None
-                    candidate_tokens: List[str] = []
-                    candidate_syllables: Optional[int] = None
-                    phrase_prefix = None
-                    phrase_suffix = None
-                    prefix_display = None
-                    suffix_display = None
-                    candidate_source_phrase = None
-                    anchor_display = None
-
-                    if isinstance(candidate, dict):
-                        target = (
-                            candidate.get("word")
-                            or candidate.get("target")
-                            or candidate.get("candidate")
-                        )
-                        similarity = float(
-                            candidate.get("similarity", candidate.get("score", 0.0))
-                        )
-                        rarity_value = float(
-                            candidate.get("rarity", candidate.get("rarity_score", 0.0))
-                        )
-                        combined = float(
-                            candidate.get("combined", candidate.get("combined_score", similarity))
-                        )
-                        is_multi_variant = bool(candidate.get("is_multi_word"))
-                        variant_candidate = (
-                            candidate.get("candidate")
-                            or (target if isinstance(target, str) else None)
-                        )
-                        candidate_tokens = candidate.get("target_tokens") or []
-                        candidate_syllables = candidate.get("candidate_syllables")
-                        phrase_prefix = candidate.get("prefix")
-                        phrase_suffix = candidate.get("suffix")
-                        prefix_display = candidate.get("prefix_display")
-                        suffix_display = candidate.get("suffix_display")
-                        candidate_source_phrase = candidate.get("source_phrase")
-                        anchor_display = candidate.get("anchor_display")
-                    else:
-                        try:
-                            target = candidate[0]
-                            similarity = float(candidate[1]) if len(candidate) > 1 else 0.0
-                            if len(candidate) > 2:
-                                rarity_value = float(candidate[2])
-                            elif rarity_source and hasattr(rarity_source, "get_rarity_score"):
-                                rarity_value = float(rarity_source.get_rarity_score(candidate[0]))
-                            else:
-                                rarity_value = 0.0
-                            combined = float(candidate[3]) if len(candidate) > 3 else similarity
-                        except Exception:
-                            target = candidate if isinstance(candidate, str) else None
-                            similarity = 0.0
-                            rarity_value = 0.0
-                            combined = 0.0
-                        variant_candidate = target if isinstance(target, str) else None
-
-                    if not target:
-                        continue
-
-                    if variant_candidate is None and isinstance(target, str):
-                        variant_candidate = target
-                    target_text = str(target)
-                    entry_is_multi = is_multi_variant or (" " in target_text.strip())
-                    entry_prefix = (
-                        phrase_prefix
-                        if phrase_prefix is not None
-                        else source_phonetic_profile.get("phrase_prefix")
-                    )
-                    entry_suffix = (
-                        phrase_suffix
-                        if phrase_suffix is not None
-                        else source_phonetic_profile.get("phrase_suffix")
-                    )
-
-                    candidate_source_phrase = (
-                        candidate_source_phrase if candidate_source_phrase is not None else source_word
-                    )
-
-                    # Attempt to evaluate cultural alignment when the cultural
-                    # engine is available; otherwise fall back to a lightweight
-                    # profile derived from the phonetic analyzer.
-                    alignment = None
-                    if cultural_engine and hasattr(cultural_engine, "evaluate_rhyme_alignment"):
-                        try:
-                            alignment = cultural_engine.evaluate_rhyme_alignment(
-                                source_word,
-                                target,
-                                threshold=phonetic_threshold,
-                                rhyme_signatures=source_signature_set,
-                                source_context=None,
-                                target_context=None,
-                            )
-                        except Exception:
-                            alignment = None
-                        if alignment is None:
+                    for candidate_word in db_candidate_words:
+                        if not candidate_word or candidate_word == source_word:
                             continue
-                    else:
-                        profile_payload: Dict[str, Any] = {}
-                        if analyzer is not None:
-                            try:
-                                profile_obj = analyzer.derive_rhyme_profile(
-                                    source_word,
-                                    target,
-                                    similarity=similarity,
-                                )
-                            except Exception:
-                                profile_obj = None
-                            if profile_obj is not None:
-                                if hasattr(profile_obj, "as_dict"):
-                                    try:
-                                        profile_payload = dict(profile_obj.as_dict())
-                                    except Exception:
-                                        profile_payload = {}
-                                elif isinstance(profile_obj, dict):
-                                    profile_payload = dict(profile_obj)
-                                else:
-                                    try:
-                                        profile_payload = dict(vars(profile_obj))
-                                    except Exception:
-                                        profile_payload = {}
-
-                        alignment = {
-                            "similarity": similarity,
-                            "rarity": rarity_value,
-                            "combined": combined,
-                            "signature_matches": [],
-                            "target_signatures": [],
-                            "features": {},
-                            "feature_profile": profile_payload,
-                            "prosody_profile": {},
-                        }
-
-                    pattern_source = candidate_source_phrase or source_word
-                    pattern_separator = " // " if entry_is_multi else " / "
-                    entry = {
-                        "source_word": pattern_source,
-                        "target_word": target_text,
-                        "artist": "CMU Pronouncing Dictionary",
-                        "song": "Phonetic Match",
-                        "pattern": f"{pattern_source}{pattern_separator}{target_text}",
-                        "distance": None,
-                        "confidence": combined,
-                        "combined_score": combined,
-                        "phonetic_sim": similarity,
-                        "rarity_score": rarity_value,
-                        "cultural_sig": "phonetic",
-                        "genre": None,
-                        "source_context": "Phonetic match suggested by the CMU Pronouncing Dictionary.",
-                        "target_context": "",
-                        "result_source": "phonetic",
-                        "source_rhyme_signatures": source_signature_list,
-                        "source_phonetic_profile": source_phonetic_profile,
-                        "phonetic_threshold": phonetic_threshold,
-                        "is_multi_word": entry_is_multi,
-                        "result_variant": "multi_word" if entry_is_multi else "single_word",
-                        "candidate_word": variant_candidate,
-                        "phrase_prefix": entry_prefix,
-                        "phrase_suffix": entry_suffix,
-                        "prefix_display": prefix_display or entry_prefix,
-                        "suffix_display": suffix_display or entry_suffix,
-                        "target_tokens": candidate_tokens,
-                        "candidate_syllables": candidate_syllables,
-                        "source_phrase": pattern_source,
-                        "source_anchor": source_anchor_word,
-                        "anchor_display": anchor_display or source_phonetic_profile.get("anchor_display"),
-                    }
-
-                    entry["phonetic_sim"] = alignment.get("similarity", entry["phonetic_sim"])
-                    if alignment.get("rarity") is not None:
-                        entry["rarity_score"] = alignment["rarity"]
-                    if alignment.get("combined") is not None:
-                        entry["combined_score"] = alignment["combined"]
                         try:
-                            entry["confidence"] = max(
-                                float(entry.get("confidence", 0.0)),
-                                float(alignment["combined"]),
-                            )
-                        except (TypeError, ValueError):
-                            entry["confidence"] = alignment["combined"]
-                    if alignment.get("rhyme_type"):
-                        entry["rhyme_type"] = alignment["rhyme_type"]
-                    entry["matched_signatures"] = alignment.get("signature_matches", [])
-                    entry["target_rhyme_signatures"] = alignment.get("target_signatures", [])
-                    features = alignment.get("features")
-                    if features:
-                        entry["phonetic_features"] = features
+                            score = float(analyzer.get_phonetic_similarity(source_word, candidate_word))
+                        except Exception:
+                            continue
+                        if score > reference_similarity:
+                            reference_similarity = score
 
-                    # Normalize optional feature profile information from the
-                    # alignment payload so that downstream UI components always
-                    # interact with plain dictionaries.
-                    feature_profile_obj = alignment.get("feature_profile") or {}
-                    feature_profile: Dict[str, Any] = {}
-                    if feature_profile_obj:
-                        if isinstance(feature_profile_obj, dict):
-                            feature_profile = dict(feature_profile_obj)
-                        else:
-                            try:
-                                feature_profile = dict(feature_profile_obj)
-                            except Exception:
-                                feature_profile = {}
-                    entry["feature_profile"] = feature_profile
-                    if feature_profile and entry.get("rhyme_type") and "rhyme_type" not in feature_profile:
-                        feature_profile["rhyme_type"] = entry["rhyme_type"]
-                    sanitized_profile = _sanitize_feature_profile(entry)
-                    if sanitized_profile:
-                        syllable_span = sanitized_profile.get("syllable_span")
-                        if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
-                            entry["syllable_span"] = [int(syllable_span[0]), int(syllable_span[1])]
-                        stress_alignment = sanitized_profile.get("stress_alignment")
-                        if stress_alignment is not None:
-                            entry["stress_alignment"] = stress_alignment
-                        internal_score = sanitized_profile.get("internal_rhyme_score")
-                        if internal_score is not None:
-                            entry["internal_rhyme_score"] = internal_score
+                phonetic_threshold = 0.7
+                if reference_similarity > 0:
+                    phonetic_threshold = max(0.6, min(0.92, reference_similarity - 0.1))
 
-                    prosody_profile = alignment.get("prosody_profile")
-                    if prosody_profile:
-                        entry["prosody_profile"] = prosody_profile
+                source_phonetics = _build_word_phonetics(source_word)
 
-                    _ensure_target_phonetics(entry)
+                prefix_tokens = []
+                suffix_tokens = []
+                if source_components.anchor_index is not None:
+                    prefix_tokens = source_components.normalized_tokens[: source_components.anchor_index]
+                    suffix_tokens = source_components.normalized_tokens[source_components.anchor_index + 1 :]
 
-                    score_for_filter = _prepare_confidence_defaults(entry)
-                    if score_for_filter < min_confidence:
-                        continue
-
-                    phonetic_entries.append(entry)
-
-                phonetic_entries.sort(
-                    key=lambda entry: (
-                        entry.get("combined_score", entry.get("confidence", 0.0)),
-                        entry.get("phonetic_sim", 0.0),
-                    ),
-                    reverse=True,
-                )
-
-                delivered_words_set = {
-                    str(item.get("target_word", "")).strip().lower()
-                    for item in phonetic_entries
-                    if item.get("target_word")
+                source_phonetic_profile = {
+                    "word": source_word,
+                    "threshold": phonetic_threshold,
+                    "reference_similarity": reference_similarity,
+                    "signatures": source_signature_list,
+                    "phonetics": source_phonetics,
+                    "anchor_word": source_anchor_word,
+                    "anchor_display": source_components.anchor_display or source_anchor_word,
+                    "phrase_tokens": source_components.normalized_tokens,
+                    "phrase_prefix": " ".join(prefix_tokens).strip(),
+                    "phrase_suffix": " ".join(suffix_tokens).strip(),
+                    "token_syllables": source_components.syllable_counts,
+                    "is_multi_word": bool(source_phonetics.get("is_multi_word")),
                 }
 
-                rare_seed_candidates: List[Dict] = []
-                for entry in phonetic_entries:
-                    target_value = entry.get("target_word")
-                    if not target_value:
-                        continue
+                phonetic_entries: List[Dict] = []
+                module1_seed_payload: List[Dict] = []
+                aggregated_seed_signatures: Set[str] = set(source_signature_set)
+                delivered_words_set: Set[str] = set()
+                if include_phonetic:
+                    slice_limit = reference_limit if reference_limit else max(limit, 1)
+                    phonetic_matches = cmu_candidates[:slice_limit]
+                    rarity_source = analyzer if analyzer is not None else getattr(self, "phonetic_analyzer", None)
+                    for candidate in phonetic_matches:
+                        is_multi_variant = False
+                        variant_candidate: Optional[str] = None
+                        candidate_tokens: List[str] = []
+                        candidate_syllables: Optional[int] = None
+                        phrase_prefix = None
+                        phrase_suffix = None
+                        prefix_display = None
+                        suffix_display = None
+                        candidate_source_phrase = None
+                        anchor_display = None
 
-                    rarity_value = entry.get("rarity_score")
-                    try:
-                        rarity_float = float(rarity_value) if rarity_value is not None else 0.0
-                    except (TypeError, ValueError):
-                        rarity_float = 0.0
-
-                    combined_value = entry.get("combined_score", entry.get("confidence", 0.0))
-                    try:
-                        combined_float = float(combined_value) if combined_value is not None else 0.0
-                    except (TypeError, ValueError):
-                        combined_float = 0.0
-
-                    signature_values = entry.get("target_rhyme_signatures") or entry.get("matched_signatures")
-                    if signature_values:
-                        signature_set = {str(sig) for sig in signature_values if sig}
-                    else:
-                        signature_set = fallback_signature(str(target_value))
-
-                    aggregated_seed_signatures.update(signature_set)
-
-                    rare_seed_candidates.append(
-                        {
-                            "word": target_value,
-                            "rarity": rarity_float,
-                            "combined": combined_float,
-                            "signatures": list(signature_set),
-                            "feature_profile": entry.get("feature_profile", {}),
-                            "prosody_profile": entry.get("prosody_profile", {}),
-                        }
-                    )
-
-                rare_seed_candidates.sort(
-                    key=lambda payload: (payload.get("rarity", 0.0), payload.get("combined", 0.0)),
-                    reverse=True,
-                )
-
-                max_seed_count = max(3, min(6, limit))
-                for candidate in rare_seed_candidates:
-                    if len(module1_seed_payload) >= max_seed_count:
-                        break
-                    if candidate.get("rarity", 0.0) <= 0 and module1_seed_payload:
-                        continue
-                    module1_seed_payload.append(candidate)
-
-            fetch_limit = None
-
-            cultural_entries: List[Dict] = []
-
-            def _context_to_dict(context_obj):
-                if context_obj is None:
-                    return None
-                if isinstance(context_obj, dict):
-                    return dict(context_obj)
-                if hasattr(context_obj, "__dict__"):
-                    return dict(vars(context_obj))
-                return {"value": context_obj}
-
-            def _enrich_with_cultural_context(entry: Dict) -> Optional[Dict]:
-                engine = getattr(self, "cultural_engine", None)
-                if not engine:
-                    return entry
-
-                entry.setdefault("source_phonetic_profile", source_phonetic_profile)
-                entry.setdefault("source_rhyme_signatures", source_signature_list)
-                entry.setdefault("phonetic_threshold", phonetic_threshold)
-                entry.setdefault("matched_signatures", [])
-                entry.setdefault("target_rhyme_signatures", [])
-
-                context_data = None
-                rarity_value = None
-
-                try:
-                    get_context = getattr(engine, "get_cultural_context", None)
-                    if callable(get_context):
-                        pattern_payload = {
-                            "artist": entry.get("artist"),
-                            "song": entry.get("song"),
-                            "source_word": entry.get("source_word", source_word),
-                            "target_word": entry.get("target_word"),
-                            "pattern": entry.get("pattern"),
-                            "cultural_significance": entry.get("cultural_sig"),
-                        }
-                        context_data = get_context(pattern_payload)
-                    elif hasattr(engine, "find_cultural_patterns"):
-                        finder = getattr(engine, "find_cultural_patterns")
-                        if callable(finder):
-                            patterns = finder(entry.get("source_word", source_word), limit=1)
-                            if patterns:
-                                pattern_info = patterns[0]
-                                context_data = pattern_info.get("cultural_context")
-                                rarity_value = pattern_info.get("cultural_rarity")
-
-                    context_dict = _context_to_dict(context_data)
-                    if context_dict:
-                        entry["cultural_context"] = context_dict
-
-                        rarity_fn = getattr(engine, "get_cultural_rarity_score", None)
-                        if callable(rarity_fn):
+                        if isinstance(candidate, dict):
+                            target = (
+                                candidate.get("word")
+                                or candidate.get("target")
+                                or candidate.get("candidate")
+                            )
+                            similarity = float(
+                                candidate.get("similarity", candidate.get("score", 0.0))
+                            )
+                            rarity_value = float(
+                                candidate.get("rarity", candidate.get("rarity_score", 0.0))
+                            )
+                            combined = float(
+                                candidate.get("combined", candidate.get("combined_score", similarity))
+                            )
+                            is_multi_variant = bool(candidate.get("is_multi_word"))
+                            variant_candidate = (
+                                candidate.get("candidate")
+                                or (target if isinstance(target, str) else None)
+                            )
+                            candidate_tokens = candidate.get("target_tokens") or []
+                            candidate_syllables = candidate.get("candidate_syllables")
+                            phrase_prefix = candidate.get("prefix")
+                            phrase_suffix = candidate.get("suffix")
+                            prefix_display = candidate.get("prefix_display")
+                            suffix_display = candidate.get("suffix_display")
+                            candidate_source_phrase = candidate.get("source_phrase")
+                            anchor_display = candidate.get("anchor_display")
+                        else:
                             try:
-                                rarity_value = rarity_fn(context_data)
-                            except (TypeError, AttributeError):
-                                rarity_value = rarity_fn(context_dict)
+                                target = candidate[0]
+                                similarity = float(candidate[1]) if len(candidate) > 1 else 0.0
+                                if len(candidate) > 2:
+                                    rarity_value = float(candidate[2])
+                                elif rarity_source and hasattr(rarity_source, "get_rarity_score"):
+                                    rarity_value = float(rarity_source.get_rarity_score(candidate[0]))
+                                else:
+                                    rarity_value = 0.0
+                                combined = float(candidate[3]) if len(candidate) > 3 else similarity
+                            except Exception:
+                                target = candidate if isinstance(candidate, str) else None
+                                similarity = 0.0
+                                rarity_value = 0.0
+                                combined = 0.0
+                            variant_candidate = target if isinstance(target, str) else None
 
-                    if rarity_value is not None:
-                        entry["cultural_rarity"] = rarity_value
+                        if not target:
+                            continue
 
-                except Exception:
-                    pass
-
-                try:
-                    evaluate_alignment = getattr(engine, "evaluate_rhyme_alignment", None)
-                    if callable(evaluate_alignment):
-                        alignment = evaluate_alignment(
-                            entry.get("source_word", source_word),
-                            entry.get("target_word"),
-                            threshold=phonetic_threshold,
-                            rhyme_signatures=source_signature_set,
-                            source_context=entry.get("source_context"),
-                            target_context=entry.get("target_context"),
+                        if variant_candidate is None and isinstance(target, str):
+                            variant_candidate = target
+                        target_text = str(target)
+                        entry_is_multi = is_multi_variant or (" " in target_text.strip())
+                        entry_prefix = (
+                            phrase_prefix
+                            if phrase_prefix is not None
+                            else source_phonetic_profile.get("phrase_prefix")
                         )
-                        if alignment is None:
-                            return None
-                        sim_value = alignment.get("similarity")
-                        if sim_value is not None:
-                            entry["phonetic_sim"] = sim_value
-                        combined_value = alignment.get("combined")
-                        if combined_value is not None:
-                            entry["combined_score"] = combined_value
+                        entry_suffix = (
+                            phrase_suffix
+                            if phrase_suffix is not None
+                            else source_phonetic_profile.get("phrase_suffix")
+                        )
+
+                        candidate_source_phrase = (
+                            candidate_source_phrase if candidate_source_phrase is not None else source_word
+                        )
+
+                        # Attempt to evaluate cultural alignment when the cultural
+                        # engine is available; otherwise fall back to a lightweight
+                        # profile derived from the phonetic analyzer.
+                        alignment = None
+                        if cultural_engine and hasattr(cultural_engine, "evaluate_rhyme_alignment"):
+                            try:
+                                alignment = cultural_engine.evaluate_rhyme_alignment(
+                                    source_word,
+                                    target,
+                                    threshold=phonetic_threshold,
+                                    rhyme_signatures=source_signature_set,
+                                    source_context=None,
+                                    target_context=None,
+                                )
+                            except Exception:
+                                alignment = None
+                            if alignment is None:
+                                continue
+                        else:
+                            profile_payload: Dict[str, Any] = {}
+                            if analyzer is not None:
+                                try:
+                                    profile_obj = analyzer.derive_rhyme_profile(
+                                        source_word,
+                                        target,
+                                        similarity=similarity,
+                                    )
+                                except Exception:
+                                    profile_obj = None
+                                if profile_obj is not None:
+                                    if hasattr(profile_obj, "as_dict"):
+                                        try:
+                                            profile_payload = dict(profile_obj.as_dict())
+                                        except Exception:
+                                            profile_payload = {}
+                                    elif isinstance(profile_obj, dict):
+                                        profile_payload = dict(profile_obj)
+                                    else:
+                                        try:
+                                            profile_payload = dict(vars(profile_obj))
+                                        except Exception:
+                                            profile_payload = {}
+
+                            alignment = {
+                                "similarity": similarity,
+                                "rarity": rarity_value,
+                                "combined": combined,
+                                "signature_matches": [],
+                                "target_signatures": [],
+                                "features": {},
+                                "feature_profile": profile_payload,
+                                "prosody_profile": {},
+                            }
+
+                        pattern_source = candidate_source_phrase or source_word
+                        pattern_separator = " // " if entry_is_multi else " / "
+                        entry = {
+                            "source_word": pattern_source,
+                            "target_word": target_text,
+                            "artist": "CMU Pronouncing Dictionary",
+                            "song": "Phonetic Match",
+                            "pattern": f"{pattern_source}{pattern_separator}{target_text}",
+                            "distance": None,
+                            "confidence": combined,
+                            "combined_score": combined,
+                            "phonetic_sim": similarity,
+                            "rarity_score": rarity_value,
+                            "cultural_sig": "phonetic",
+                            "genre": None,
+                            "source_context": "Phonetic match suggested by the CMU Pronouncing Dictionary.",
+                            "target_context": "",
+                            "result_source": "phonetic",
+                            "source_rhyme_signatures": source_signature_list,
+                            "source_phonetic_profile": source_phonetic_profile,
+                            "phonetic_threshold": phonetic_threshold,
+                            "is_multi_word": entry_is_multi,
+                            "result_variant": "multi_word" if entry_is_multi else "single_word",
+                            "candidate_word": variant_candidate,
+                            "phrase_prefix": entry_prefix,
+                            "phrase_suffix": entry_suffix,
+                            "prefix_display": prefix_display or entry_prefix,
+                            "suffix_display": suffix_display or entry_suffix,
+                            "target_tokens": candidate_tokens,
+                            "candidate_syllables": candidate_syllables,
+                            "source_phrase": pattern_source,
+                            "source_anchor": source_anchor_word,
+                            "anchor_display": anchor_display or source_phonetic_profile.get("anchor_display"),
+                        }
+
+                        entry["phonetic_sim"] = alignment.get("similarity", entry["phonetic_sim"])
+                        if alignment.get("rarity") is not None:
+                            entry["rarity_score"] = alignment["rarity"]
+                        if alignment.get("combined") is not None:
+                            entry["combined_score"] = alignment["combined"]
                             try:
                                 entry["confidence"] = max(
                                     float(entry.get("confidence", 0.0)),
-                                    float(combined_value),
+                                    float(alignment["combined"]),
                                 )
                             except (TypeError, ValueError):
-                                entry["confidence"] = combined_value
-                        rarity_metric = alignment.get("rarity")
-                        if rarity_metric is not None:
-                            entry["rarity_score"] = rarity_metric
-                        rhyme_type = alignment.get("rhyme_type")
-                        if rhyme_type:
-                            entry["rhyme_type"] = rhyme_type
-                        entry["matched_signatures"] = alignment.get(
-                            "signature_matches", entry.get("matched_signatures", [])
-                        )
-                        entry["target_rhyme_signatures"] = alignment.get(
-                            "target_signatures", entry.get("target_rhyme_signatures", [])
-                        )
+                                entry["confidence"] = alignment["combined"]
+                        if alignment.get("rhyme_type"):
+                            entry["rhyme_type"] = alignment["rhyme_type"]
+                        entry["matched_signatures"] = alignment.get("signature_matches", [])
+                        entry["target_rhyme_signatures"] = alignment.get("target_signatures", [])
                         features = alignment.get("features")
                         if features:
                             entry["phonetic_features"] = features
-                        feature_profile_obj = alignment.get("feature_profile")
+
+                        # Normalize optional feature profile information from the
+                        # alignment payload so that downstream UI components always
+                        # interact with plain dictionaries.
+                        feature_profile_obj = alignment.get("feature_profile") or {}
                         feature_profile: Dict[str, Any] = {}
                         if feature_profile_obj:
                             if isinstance(feature_profile_obj, dict):
@@ -975,644 +904,915 @@ class SearchService:
                                     feature_profile = dict(feature_profile_obj)
                                 except Exception:
                                     feature_profile = {}
-                        if feature_profile:
-                            if entry.get("rhyme_type") and "rhyme_type" not in feature_profile:
-                                feature_profile["rhyme_type"] = entry["rhyme_type"]
-                            entry["feature_profile"] = feature_profile
-                            syllable_span = feature_profile.get("syllable_span")
+                        entry["feature_profile"] = feature_profile
+                        if feature_profile and entry.get("rhyme_type") and "rhyme_type" not in feature_profile:
+                            feature_profile["rhyme_type"] = entry["rhyme_type"]
+                        sanitized_profile = _sanitize_feature_profile(entry)
+                        if sanitized_profile:
+                            syllable_span = sanitized_profile.get("syllable_span")
                             if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
                                 entry["syllable_span"] = [int(syllable_span[0]), int(syllable_span[1])]
-                            stress_alignment = feature_profile.get("stress_alignment")
+                            stress_alignment = sanitized_profile.get("stress_alignment")
                             if stress_alignment is not None:
                                 entry["stress_alignment"] = stress_alignment
-                            internal_score = feature_profile.get("internal_rhyme_score")
+                            internal_score = sanitized_profile.get("internal_rhyme_score")
                             if internal_score is not None:
                                 entry["internal_rhyme_score"] = internal_score
+
                         prosody_profile = alignment.get("prosody_profile")
                         if prosody_profile:
                             entry["prosody_profile"] = prosody_profile
-                except Exception:
-                    pass
 
-                _sanitize_feature_profile(entry)
-                _ensure_target_phonetics(entry)
-                return entry
+                        _ensure_target_phonetics(entry)
 
-            source_results: List[Tuple] = []
-            target_results: List[Tuple] = []
+                        score_for_filter = _prepare_confidence_defaults(entry)
+                        if score_for_filter < min_confidence:
+                            continue
 
-            if include_cultural and self.repository:
-                try:
-                    source_results, target_results = self.repository.fetch_cultural_matches(
-                        source_word,
-                        min_confidence=min_confidence,
-                        phonetic_threshold=phonetic_threshold,
-                        cultural_filters=sorted(cultural_filters),
-                        genre_filters=sorted(genre_filters),
-                        max_line_distance=max_line_distance,
-                        limit=fetch_limit,
+                        phonetic_entries.append(entry)
+
+                    phonetic_entries.sort(
+                        key=lambda entry: (
+                            entry.get("combined_score", entry.get("confidence", 0.0)),
+                            entry.get("phonetic_sim", 0.0),
+                        ),
+                        reverse=True,
                     )
-                except Exception:
-                    source_results, target_results = [], []
 
-            def build_entry(row: Tuple, swap: bool = False) -> Optional[Dict]:
-                entry = {
-                    "source_word": row[0],
-                    "target_word": row[1],
-                    "artist": row[2],
-                    "song": row[3],
-                    "pattern": row[4],
-                    "genre": row[5],
-                    "distance": row[6],
-                    "confidence": row[7],
-                    "phonetic_sim": row[8],
-                    "cultural_sig": row[9],
-                    "source_context": row[10],
-                    "target_context": row[11],
-                    "result_source": "cultural",
-                    "combined_score": row[7],
-                    "source_phonetic_profile": source_phonetic_profile,
-                    "source_rhyme_signatures": source_signature_list,
-                    "phonetic_threshold": phonetic_threshold,
-                }
+                    delivered_words_set = {
+                        str(item.get("target_word", "")).strip().lower()
+                        for item in phonetic_entries
+                        if item.get("target_word")
+                    }
 
-                if swap:
-                    swapped_source = row[1]
-                    swapped_target = row[0]
-                    swapped_pattern = entry["pattern"]
-                    if swapped_source and swapped_target:
-                        swapped_pattern = f"{swapped_source} / {swapped_target}"
+                    rare_seed_candidates: List[Dict] = []
+                    for entry in phonetic_entries:
+                        target_value = entry.get("target_word")
+                        if not target_value:
+                            continue
+
+                        rarity_value = entry.get("rarity_score")
+                        try:
+                            rarity_float = float(rarity_value) if rarity_value is not None else 0.0
+                        except (TypeError, ValueError):
+                            rarity_float = 0.0
+
+                        combined_value = entry.get("combined_score", entry.get("confidence", 0.0))
+                        try:
+                            combined_float = float(combined_value) if combined_value is not None else 0.0
+                        except (TypeError, ValueError):
+                            combined_float = 0.0
+
+                        signature_values = entry.get("target_rhyme_signatures") or entry.get("matched_signatures")
+                        if signature_values:
+                            signature_set = {str(sig) for sig in signature_values if sig}
+                        else:
+                            signature_set = fallback_signature(str(target_value))
+
+                        aggregated_seed_signatures.update(signature_set)
+
+                        rare_seed_candidates.append(
+                            {
+                                "word": target_value,
+                                "rarity": rarity_float,
+                                "combined": combined_float,
+                                "signatures": list(signature_set),
+                                "feature_profile": entry.get("feature_profile", {}),
+                                "prosody_profile": entry.get("prosody_profile", {}),
+                            }
+                        )
+
+                    rare_seed_candidates.sort(
+                        key=lambda payload: (payload.get("rarity", 0.0), payload.get("combined", 0.0)),
+                        reverse=True,
+                    )
+
+                    max_seed_count = max(3, min(6, limit))
+                    for candidate in rare_seed_candidates:
+                        if len(module1_seed_payload) >= max_seed_count:
+                            break
+                        if candidate.get("rarity", 0.0) <= 0 and module1_seed_payload:
+                            continue
+                        module1_seed_payload.append(candidate)
+
+                fetch_limit = None
+
+                cultural_entries: List[Dict] = []
+
+                def _context_to_dict(context_obj):
+                    if context_obj is None:
+                        return None
+                    if isinstance(context_obj, dict):
+                        return dict(context_obj)
+                    if hasattr(context_obj, "__dict__"):
+                        return dict(vars(context_obj))
+                    return {"value": context_obj}
+
+                def _enrich_with_cultural_context(entry: Dict) -> Optional[Dict]:
+                    engine = getattr(self, "cultural_engine", None)
+                    if not engine:
+                        return entry
+
+                    entry.setdefault("source_phonetic_profile", source_phonetic_profile)
+                    entry.setdefault("source_rhyme_signatures", source_signature_list)
+                    entry.setdefault("phonetic_threshold", phonetic_threshold)
+                    entry.setdefault("matched_signatures", [])
+                    entry.setdefault("target_rhyme_signatures", [])
+
+                    context_data = None
+                    rarity_value = None
+
+                    try:
+                        get_context = getattr(engine, "get_cultural_context", None)
+                        if callable(get_context):
+                            pattern_payload = {
+                                "artist": entry.get("artist"),
+                                "song": entry.get("song"),
+                                "source_word": entry.get("source_word", source_word),
+                                "target_word": entry.get("target_word"),
+                                "pattern": entry.get("pattern"),
+                                "cultural_significance": entry.get("cultural_sig"),
+                            }
+                            context_data = get_context(pattern_payload)
+                        elif hasattr(engine, "find_cultural_patterns"):
+                            finder = getattr(engine, "find_cultural_patterns")
+                            if callable(finder):
+                                patterns = finder(entry.get("source_word", source_word), limit=1)
+                                if patterns:
+                                    pattern_info = patterns[0]
+                                    context_data = pattern_info.get("cultural_context")
+                                    rarity_value = pattern_info.get("cultural_rarity")
+
+                        context_dict = _context_to_dict(context_data)
+                        if context_dict:
+                            entry["cultural_context"] = context_dict
+
+                            rarity_fn = getattr(engine, "get_cultural_rarity_score", None)
+                            if callable(rarity_fn):
+                                try:
+                                    rarity_value = rarity_fn(context_data)
+                                except (TypeError, AttributeError):
+                                    rarity_value = rarity_fn(context_dict)
+
+                        if rarity_value is not None:
+                            entry["cultural_rarity"] = rarity_value
+
+                    except Exception:
+                        pass
+
+                    try:
+                        evaluate_alignment = getattr(engine, "evaluate_rhyme_alignment", None)
+                        if callable(evaluate_alignment):
+                            alignment = evaluate_alignment(
+                                entry.get("source_word", source_word),
+                                entry.get("target_word"),
+                                threshold=phonetic_threshold,
+                                rhyme_signatures=source_signature_set,
+                                source_context=entry.get("source_context"),
+                                target_context=entry.get("target_context"),
+                            )
+                            if alignment is None:
+                                return None
+                            sim_value = alignment.get("similarity")
+                            if sim_value is not None:
+                                entry["phonetic_sim"] = sim_value
+                            combined_value = alignment.get("combined")
+                            if combined_value is not None:
+                                entry["combined_score"] = combined_value
+                                try:
+                                    entry["confidence"] = max(
+                                        float(entry.get("confidence", 0.0)),
+                                        float(combined_value),
+                                    )
+                                except (TypeError, ValueError):
+                                    entry["confidence"] = combined_value
+                            rarity_metric = alignment.get("rarity")
+                            if rarity_metric is not None:
+                                entry["rarity_score"] = rarity_metric
+                            rhyme_type = alignment.get("rhyme_type")
+                            if rhyme_type:
+                                entry["rhyme_type"] = rhyme_type
+                            entry["matched_signatures"] = alignment.get(
+                                "signature_matches", entry.get("matched_signatures", [])
+                            )
+                            entry["target_rhyme_signatures"] = alignment.get(
+                                "target_signatures", entry.get("target_rhyme_signatures", [])
+                            )
+                            features = alignment.get("features")
+                            if features:
+                                entry["phonetic_features"] = features
+                            feature_profile_obj = alignment.get("feature_profile")
+                            feature_profile: Dict[str, Any] = {}
+                            if feature_profile_obj:
+                                if isinstance(feature_profile_obj, dict):
+                                    feature_profile = dict(feature_profile_obj)
+                                else:
+                                    try:
+                                        feature_profile = dict(feature_profile_obj)
+                                    except Exception:
+                                        feature_profile = {}
+                            if feature_profile:
+                                if entry.get("rhyme_type") and "rhyme_type" not in feature_profile:
+                                    feature_profile["rhyme_type"] = entry["rhyme_type"]
+                                entry["feature_profile"] = feature_profile
+                                syllable_span = feature_profile.get("syllable_span")
+                                if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
+                                    entry["syllable_span"] = [int(syllable_span[0]), int(syllable_span[1])]
+                                stress_alignment = feature_profile.get("stress_alignment")
+                                if stress_alignment is not None:
+                                    entry["stress_alignment"] = stress_alignment
+                                internal_score = feature_profile.get("internal_rhyme_score")
+                                if internal_score is not None:
+                                    entry["internal_rhyme_score"] = internal_score
+                            prosody_profile = alignment.get("prosody_profile")
+                            if prosody_profile:
+                                entry["prosody_profile"] = prosody_profile
+                    except Exception:
+                        pass
+
+                    _sanitize_feature_profile(entry)
+                    _ensure_target_phonetics(entry)
+                    return entry
+
+                source_results: List[Tuple] = []
+                target_results: List[Tuple] = []
+
+                if include_cultural and self.repository:
+                    with observe_stage_latency(
+                        "cultural_lookup",
+                        span_name="search.cultural",
+                        filters=len(cultural_filters),
+                        genres=len(genre_filters),
+                    ):
+                        try:
+                            source_results, target_results = self.repository.fetch_cultural_matches(
+                                source_word,
+                                min_confidence=min_confidence,
+                                phonetic_threshold=phonetic_threshold,
+                                cultural_filters=sorted(cultural_filters),
+                                genre_filters=sorted(genre_filters),
+                                max_line_distance=max_line_distance,
+                                limit=fetch_limit,
+                            )
+                        except Exception:
+                            record_search_error(
+                                "cultural",
+                                source_word=source_word,
+                                filters=list(cultural_filters),
+                                genres=list(genre_filters),
+                            )
+                            logger.exception(
+                                "repository.cultural_lookup_failed",
+                                extra={
+                                    "source_word": source_word,
+                                    "filters": list(cultural_filters),
+                                    "genres": list(genre_filters),
+                                },
+                            )
+                            source_results, target_results = [], []
+
+                def build_entry(row: Tuple, swap: bool = False) -> Optional[Dict]:
                     entry = {
-                        **entry,
-                        "source_word": swapped_source,
-                        "target_word": swapped_target,
-                        "pattern": swapped_pattern,
-                        "source_context": row[11],
-                        "target_context": row[10],
-                    }
-
-                target_text = str(entry.get("target_word", ""))
-                is_multi = " " in target_text.strip() if target_text else False
-                entry.setdefault("is_multi_word", is_multi)
-                entry.setdefault("result_variant", "multi_word" if is_multi else "single_word")
-                if is_multi and target_text:
-                    entry["pattern"] = f"{entry.get('source_word', source_word)} // {target_text}"
-                entry.setdefault("source_phrase", entry.get("source_word", source_word))
-                entry.setdefault("source_anchor", source_anchor_word)
-                entry.setdefault("anchor_display", source_phonetic_profile.get("anchor_display"))
-                entry.setdefault("phrase_prefix", source_phonetic_profile.get("phrase_prefix"))
-                entry.setdefault("phrase_suffix", source_phonetic_profile.get("phrase_suffix"))
-
-                return _enrich_with_cultural_context(entry)
-
-            for row in source_results:
-                enriched_entry = build_entry(row)
-                if enriched_entry:
-                    cultural_entries.append(enriched_entry)
-
-            for row in target_results:
-                enriched_entry = build_entry(row, swap=True)
-                if enriched_entry:
-                    cultural_entries.append(enriched_entry)
-
-            cultural_entries.sort(
-                key=lambda r: (
-                    -float(r.get("confidence", 0.0)),
-                    -float(r.get("phonetic_sim", 0.0)),
-                )
-            )
-
-            anti_llm_entries: List[Dict] = []
-            if include_anti_llm:
-                anti_patterns = self.anti_llm_engine.generate_anti_llm_patterns(
-                    source_word,
-                    limit=limit,
-                    module1_seeds=module1_seed_payload,
-                    seed_signatures=aggregated_seed_signatures,
-                    delivered_words=delivered_words_set,
-                )
-                for pattern in anti_patterns:
-                    feature_profile = getattr(pattern, "feature_profile", {}) or {}
-                    syllable_span = getattr(pattern, "syllable_span", None)
-                    stress_alignment = getattr(pattern, "stress_alignment", None)
-                    internal_rhyme = None
-                    if isinstance(feature_profile, dict):
-                        internal_rhyme = feature_profile.get("internal_rhyme_score")
-                    confidence_float = _coerce_float(getattr(pattern, "confidence", None))
-                    if confidence_float is None:
-                        confidence_float = 0.0
-                    combined_metric = getattr(pattern, "combined", None)
-                    if combined_metric is None:
-                        combined_metric = getattr(pattern, "combined_score", None)
-                    combined_float = _coerce_float(combined_metric)
-                    entry_payload = {
-                        "source_word": source_word,
-                        "target_word": pattern.target_word,
-                        "pattern": f"{source_word} / {pattern.target_word}",
-                        "confidence": confidence_float,
-                        "rarity_score": pattern.rarity_score,
-                        "llm_weakness_type": pattern.llm_weakness_type,
-                        "cultural_depth": pattern.cultural_depth,
-                        "result_source": "anti_llm",
-                        "source_rhyme_signatures": source_signature_list,
+                        "source_word": row[0],
+                        "target_word": row[1],
+                        "artist": row[2],
+                        "song": row[3],
+                        "pattern": row[4],
+                        "genre": row[5],
+                        "distance": row[6],
+                        "confidence": row[7],
+                        "phonetic_sim": row[8],
+                        "cultural_sig": row[9],
+                        "source_context": row[10],
+                        "target_context": row[11],
+                        "result_source": "cultural",
+                        "combined_score": row[7],
                         "source_phonetic_profile": source_phonetic_profile,
+                        "source_rhyme_signatures": source_signature_list,
                         "phonetic_threshold": phonetic_threshold,
-                        "feature_profile": feature_profile,
-                        "bradley_device": getattr(pattern, "bradley_device", None),
-                        "stress_alignment": stress_alignment,
-                        "internal_rhyme_score": internal_rhyme,
                     }
-                    is_multi = " " in str(pattern.target_word or "").strip()
-                    entry_payload["is_multi_word"] = is_multi
-                    entry_payload["result_variant"] = "multi_word" if is_multi else "single_word"
-                    if is_multi and pattern.target_word:
-                        entry_payload["pattern"] = f"{source_word} // {pattern.target_word}"
-                    entry_payload.setdefault("source_phrase", source_word)
-                    entry_payload.setdefault("source_anchor", source_anchor_word)
-                    entry_payload.setdefault("anchor_display", source_phonetic_profile.get("anchor_display"))
-                    entry_payload.setdefault("phrase_prefix", source_phonetic_profile.get("phrase_prefix"))
-                    entry_payload.setdefault("phrase_suffix", source_phonetic_profile.get("phrase_suffix"))
-                    if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
-                        entry_payload["syllable_span"] = [int(syllable_span[0]), int(syllable_span[1])]
-                    prosody_payload = getattr(pattern, "prosody_profile", None)
-                    if isinstance(prosody_payload, dict):
-                        entry_payload["prosody_profile"] = prosody_payload
-                    entry_payload["combined_score"] = (
-                        combined_float if combined_float is not None else confidence_float
+
+                    if swap:
+                        swapped_source = row[1]
+                        swapped_target = row[0]
+                        swapped_pattern = entry["pattern"]
+                        if swapped_source and swapped_target:
+                            swapped_pattern = f"{swapped_source} / {swapped_target}"
+                        entry = {
+                            **entry,
+                            "source_word": swapped_source,
+                            "target_word": swapped_target,
+                            "pattern": swapped_pattern,
+                            "source_context": row[11],
+                            "target_context": row[10],
+                        }
+
+                    target_text = str(entry.get("target_word", ""))
+                    is_multi = " " in target_text.strip() if target_text else False
+                    entry.setdefault("is_multi_word", is_multi)
+                    entry.setdefault("result_variant", "multi_word" if is_multi else "single_word")
+                    if is_multi and target_text:
+                        entry["pattern"] = f"{entry.get('source_word', source_word)} // {target_text}"
+                    entry.setdefault("source_phrase", entry.get("source_word", source_word))
+                    entry.setdefault("source_anchor", source_anchor_word)
+                    entry.setdefault("anchor_display", source_phonetic_profile.get("anchor_display"))
+                    entry.setdefault("phrase_prefix", source_phonetic_profile.get("phrase_prefix"))
+                    entry.setdefault("phrase_suffix", source_phonetic_profile.get("phrase_suffix"))
+
+                    return _enrich_with_cultural_context(entry)
+
+                for row in source_results:
+                    enriched_entry = build_entry(row)
+                    if enriched_entry:
+                        cultural_entries.append(enriched_entry)
+
+                for row in target_results:
+                    enriched_entry = build_entry(row, swap=True)
+                    if enriched_entry:
+                        cultural_entries.append(enriched_entry)
+
+                cultural_entries.sort(
+                    key=lambda r: (
+                        -float(r.get("confidence", 0.0)),
+                        -float(r.get("phonetic_sim", 0.0)),
                     )
-                    _sanitize_feature_profile(entry_payload)
-                    _ensure_target_phonetics(entry_payload)
-                    score_for_filter = _prepare_confidence_defaults(entry_payload)
-                    if score_for_filter < min_confidence:
-                        continue
-                    anti_llm_entries.append(entry_payload)
+                )
 
-            def _passes_min_confidence(entry: Dict) -> bool:
-                score = _prepare_confidence_defaults(entry)
-                return score >= min_confidence
+                anti_llm_entries: List[Dict] = []
+                if include_anti_llm:
+                    with observe_stage_latency(
+                        "anti_llm_generation",
+                        span_name="search.anti_llm",
+                        limit=limit,
+                    ):
+                        try:
+                            anti_patterns = self.anti_llm_engine.generate_anti_llm_patterns(
+                                source_word,
+                                limit=limit,
+                                module1_seeds=module1_seed_payload,
+                                seed_signatures=aggregated_seed_signatures,
+                                delivered_words=delivered_words_set,
+                            )
+                        except Exception:
+                            record_search_error(
+                                "anti_llm",
+                                source_word=source_word,
+                                delivered=len(delivered_words_set),
+                            )
+                            logger.exception(
+                                "anti_llm.generation_failed",
+                                extra={
+                                    "source_word": source_word,
+                                    "delivered_words": len(delivered_words_set),
+                                },
+                            )
+                            anti_patterns = []
+                    for pattern in anti_patterns:
+                        feature_profile = getattr(pattern, "feature_profile", {}) or {}
+                        syllable_span = getattr(pattern, "syllable_span", None)
+                        stress_alignment = getattr(pattern, "stress_alignment", None)
+                        internal_rhyme = None
+                        if isinstance(feature_profile, dict):
+                            internal_rhyme = feature_profile.get("internal_rhyme_score")
+                        confidence_float = _coerce_float(getattr(pattern, "confidence", None))
+                        if confidence_float is None:
+                            confidence_float = 0.0
+                        combined_metric = getattr(pattern, "combined", None)
+                        if combined_metric is None:
+                            combined_metric = getattr(pattern, "combined_score", None)
+                        combined_float = _coerce_float(combined_metric)
+                        entry_payload = {
+                            "source_word": source_word,
+                            "target_word": pattern.target_word,
+                            "pattern": f"{source_word} / {pattern.target_word}",
+                            "confidence": confidence_float,
+                            "rarity_score": pattern.rarity_score,
+                            "llm_weakness_type": pattern.llm_weakness_type,
+                            "cultural_depth": pattern.cultural_depth,
+                            "result_source": "anti_llm",
+                            "source_rhyme_signatures": source_signature_list,
+                            "source_phonetic_profile": source_phonetic_profile,
+                            "phonetic_threshold": phonetic_threshold,
+                            "feature_profile": feature_profile,
+                            "bradley_device": getattr(pattern, "bradley_device", None),
+                            "stress_alignment": stress_alignment,
+                            "internal_rhyme_score": internal_rhyme,
+                        }
+                        is_multi = " " in str(pattern.target_word or "").strip()
+                        entry_payload["is_multi_word"] = is_multi
+                        entry_payload["result_variant"] = "multi_word" if is_multi else "single_word"
+                        if is_multi and pattern.target_word:
+                            entry_payload["pattern"] = f"{source_word} // {pattern.target_word}"
+                        entry_payload.setdefault("source_phrase", source_word)
+                        entry_payload.setdefault("source_anchor", source_anchor_word)
+                        entry_payload.setdefault("anchor_display", source_phonetic_profile.get("anchor_display"))
+                        entry_payload.setdefault("phrase_prefix", source_phonetic_profile.get("phrase_prefix"))
+                        entry_payload.setdefault("phrase_suffix", source_phonetic_profile.get("phrase_suffix"))
+                        if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
+                            entry_payload["syllable_span"] = [int(syllable_span[0]), int(syllable_span[1])]
+                        prosody_payload = getattr(pattern, "prosody_profile", None)
+                        if isinstance(prosody_payload, dict):
+                            entry_payload["prosody_profile"] = prosody_payload
+                        entry_payload["combined_score"] = (
+                            combined_float if combined_float is not None else confidence_float
+                        )
+                        _sanitize_feature_profile(entry_payload)
+                        _ensure_target_phonetics(entry_payload)
+                        score_for_filter = _prepare_confidence_defaults(entry_payload)
+                        if score_for_filter < min_confidence:
+                            continue
+                        anti_llm_entries.append(entry_payload)
 
-            def _ensure_feature_profile(entry: Dict) -> Dict[str, Any]:
-                """Return a mutable feature profile dictionary for ``entry``."""
+                def _passes_min_confidence(entry: Dict) -> bool:
+                    score = _prepare_confidence_defaults(entry)
+                    return score >= min_confidence
 
-                profile_obj = entry.get("feature_profile")
-                if isinstance(profile_obj, dict):
-                    return profile_obj
-                if profile_obj is None:
-                    profile_dict: Dict[str, Any] = {}
-                elif hasattr(profile_obj, "__dict__"):
-                    try:
-                        profile_dict = dict(vars(profile_obj))
-                    except Exception:
-                        profile_dict = {}
-                else:
-                    try:
-                        profile_dict = dict(profile_obj)
-                    except Exception:
-                        profile_dict = {}
-                entry["feature_profile"] = profile_dict
-                return profile_dict
+                def _ensure_feature_profile(entry: Dict) -> Dict[str, Any]:
+                    """Return a mutable feature profile dictionary for ``entry``."""
 
-            def _extract_rhyme_category(entry: Dict) -> Optional[str]:
-                """Pull a rhyme category label from an entry and normalise storage."""
-
-                rhyme_value = entry.get("rhyme_type")
-                if not rhyme_value:
-                    features_obj = entry.get("phonetic_features")
-                    if features_obj is not None:
-                        if isinstance(features_obj, dict):
-                            rhyme_value = features_obj.get("rhyme_type")
-                        elif hasattr(features_obj, "__dict__"):
-                            rhyme_value = vars(features_obj).get("rhyme_type")
-                        else:
-                            try:
-                                rhyme_value = dict(features_obj).get("rhyme_type")
-                            except Exception:
-                                rhyme_value = None
-                if not rhyme_value:
                     profile_obj = entry.get("feature_profile")
-                    if profile_obj is not None:
-                        if isinstance(profile_obj, dict):
-                            rhyme_value = profile_obj.get("rhyme_type")
-                        elif hasattr(profile_obj, "__dict__"):
-                            rhyme_value = vars(profile_obj).get("rhyme_type")
-                        else:
-                            try:
-                                rhyme_value = dict(profile_obj).get("rhyme_type")
-                            except Exception:
-                                rhyme_value = None
-                if rhyme_value:
-                    entry["rhyme_type"] = rhyme_value
+                    if isinstance(profile_obj, dict):
+                        return profile_obj
+                    if profile_obj is None:
+                        profile_dict: Dict[str, Any] = {}
+                    elif hasattr(profile_obj, "__dict__"):
+                        try:
+                            profile_dict = dict(vars(profile_obj))
+                        except Exception:
+                            profile_dict = {}
+                    else:
+                        try:
+                            profile_dict = dict(profile_obj)
+                        except Exception:
+                            profile_dict = {}
+                    entry["feature_profile"] = profile_dict
+                    return profile_dict
+
+                def _extract_rhyme_category(entry: Dict) -> Optional[str]:
+                    """Pull a rhyme category label from an entry and normalise storage."""
+
+                    rhyme_value = entry.get("rhyme_type")
+                    if not rhyme_value:
+                        features_obj = entry.get("phonetic_features")
+                        if features_obj is not None:
+                            if isinstance(features_obj, dict):
+                                rhyme_value = features_obj.get("rhyme_type")
+                            elif hasattr(features_obj, "__dict__"):
+                                rhyme_value = vars(features_obj).get("rhyme_type")
+                            else:
+                                try:
+                                    rhyme_value = dict(features_obj).get("rhyme_type")
+                                except Exception:
+                                    rhyme_value = None
+                    if not rhyme_value:
+                        profile_obj = entry.get("feature_profile")
+                        if profile_obj is not None:
+                            if isinstance(profile_obj, dict):
+                                rhyme_value = profile_obj.get("rhyme_type")
+                            elif hasattr(profile_obj, "__dict__"):
+                                rhyme_value = vars(profile_obj).get("rhyme_type")
+                            else:
+                                try:
+                                    rhyme_value = dict(profile_obj).get("rhyme_type")
+                                except Exception:
+                                    rhyme_value = None
+                    if rhyme_value:
+                        entry["rhyme_type"] = rhyme_value
+                        profile_dict = _ensure_feature_profile(entry)
+                        profile_dict.setdefault("rhyme_type", rhyme_value)
+                    return rhyme_value
+
+                def _extract_rhythm_score(entry: Dict) -> Optional[float]:
+                    """Return a numeric rhythm/stress alignment score for an entry."""
+
+                    raw_value = entry.get("rhythm_score")
+                    if raw_value is None:
+                        raw_value = entry.get("stress_alignment")
+                    if raw_value is None:
+                        profile_obj = entry.get("feature_profile")
+                        if profile_obj is not None:
+                            if isinstance(profile_obj, dict):
+                                raw_value = profile_obj.get("stress_alignment")
+                            elif hasattr(profile_obj, "__dict__"):
+                                raw_value = vars(profile_obj).get("stress_alignment")
+                            else:
+                                try:
+                                    raw_value = dict(profile_obj).get("stress_alignment")
+                                except Exception:
+                                    raw_value = None
+                    if raw_value is None:
+                        phonetic_features = entry.get("phonetic_features")
+                        if phonetic_features is not None:
+                            if isinstance(phonetic_features, dict):
+                                raw_value = phonetic_features.get("stress_alignment")
+                            elif hasattr(phonetic_features, "__dict__"):
+                                raw_value = vars(phonetic_features).get("stress_alignment")
+                            else:
+                                try:
+                                    raw_value = dict(phonetic_features).get("stress_alignment")
+                                except Exception:
+                                    raw_value = None
+                    try:
+                        rhythm_float = float(raw_value)
+                    except (TypeError, ValueError):
+                        return None
+
+                    entry["rhythm_score"] = rhythm_float
+                    entry["stress_alignment"] = rhythm_float
                     profile_dict = _ensure_feature_profile(entry)
-                    profile_dict.setdefault("rhyme_type", rhyme_value)
-                return rhyme_value
+                    profile_dict.setdefault("stress_alignment", rhythm_float)
+                    return rhythm_float
 
-            def _extract_rhythm_score(entry: Dict) -> Optional[float]:
-                """Return a numeric rhythm/stress alignment score for an entry."""
+                def _filter_entry(entry: Dict) -> bool:
+                    if not _passes_min_confidence(entry):
+                        return False
 
-                raw_value = entry.get("rhythm_score")
-                if raw_value is None:
-                    raw_value = entry.get("stress_alignment")
-                if raw_value is None:
-                    profile_obj = entry.get("feature_profile")
-                    if profile_obj is not None:
-                        if isinstance(profile_obj, dict):
-                            raw_value = profile_obj.get("stress_alignment")
-                        elif hasattr(profile_obj, "__dict__"):
-                            raw_value = vars(profile_obj).get("stress_alignment")
-                        else:
+                    entry_rhyme = _extract_rhyme_category(entry)
+                    rhythm_score = _extract_rhythm_score(entry)
+
+                    if not filters_active:
+                        return True
+
+                    if cultural_filters:
+                        sig = entry.get("cultural_sig")
+                        if sig is None or normalize_name(str(sig)) not in cultural_filters:
+                            return False
+                    if genre_filters:
+                        genre_value = entry.get("genre")
+                        if genre_value is None or normalize_name(str(genre_value)) not in genre_filters:
+                            return False
+                    if rhyme_type_filters:
+                        if not entry_rhyme or normalize_name(str(entry_rhyme)) not in rhyme_type_filters:
+                            return False
+                    if bradley_filters:
+                        device_value = entry.get("bradley_device")
+                        if device_value is None and entry.get("feature_profile"):
+                            device_value = entry["feature_profile"].get("bradley_device")
+                        if device_value is None and entry.get("_bradley_device"):
+                            device_value = entry.get("_bradley_device")
+                        if (
+                            device_value is None
+                            or normalize_name(str(device_value)) not in bradley_filters
+                        ):
+                            return False
+                    if min_rarity_threshold is not None:
+                        rarity_metric = entry.get("rarity_score")
+                        if rarity_metric is None:
+                            rarity_metric = entry.get("cultural_rarity")
+                        try:
+                            rarity_value = float(rarity_metric) if rarity_metric is not None else 0.0
+                        except (TypeError, ValueError):
+                            rarity_value = 0.0
+                        if rarity_value < min_rarity_threshold:
+                            return False
+                    if min_stress_threshold is not None:
+                        if rhythm_score is None or rhythm_score < min_stress_threshold:
+                            return False
+                    if cadence_focus_normalized:
+                        prosody = entry.get("prosody_profile") or {}
+                        cadence_value = prosody.get("complexity_tag") if isinstance(prosody, dict) else None
+                        if cadence_value is None:
+                            cadence_value = entry.get("feature_profile", {}).get("complexity_tag")
+                        if not cadence_value or normalize_name(str(cadence_value)) != cadence_focus_normalized:
+                            return False
+                    if require_internal:
+                        internal_value = entry.get("internal_rhyme_score")
+                        if internal_value is None and entry.get("feature_profile"):
+                            internal_value = entry["feature_profile"].get("internal_rhyme_score")
+                        try:
+                            internal_float = float(internal_value) if internal_value is not None else 0.0
+                        except (TypeError, ValueError):
+                            internal_float = 0.0
+                        if internal_float < 0.4:
+                            return False
+                    if min_syllable_threshold is not None or max_syllable_threshold is not None:
+                        syllable_span = entry.get("syllable_span")
+                        if not syllable_span and entry.get("feature_profile"):
+                            syllable_span = entry["feature_profile"].get("syllable_span")
+                        if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
                             try:
-                                raw_value = dict(profile_obj).get("stress_alignment")
-                            except Exception:
-                                raw_value = None
-                if raw_value is None:
-                    phonetic_features = entry.get("phonetic_features")
-                    if phonetic_features is not None:
-                        if isinstance(phonetic_features, dict):
-                            raw_value = phonetic_features.get("stress_alignment")
-                        elif hasattr(phonetic_features, "__dict__"):
-                            raw_value = vars(phonetic_features).get("stress_alignment")
+                                target_syllables = int(syllable_span[1])
+                            except (TypeError, ValueError):
+                                target_syllables = None
                         else:
+                            target_word = entry.get("target_word")
                             try:
-                                raw_value = dict(phonetic_features).get("stress_alignment")
+                                estimator = getattr(self.phonetic_analyzer, "estimate_syllables", None)
+                                if callable(estimator):
+                                    target_syllables = estimator(str(target_word)) if target_word else None
+                                else:
+                                    target_syllables = self.phonetic_analyzer._count_syllables(str(target_word)) if target_word else None
                             except Exception:
-                                raw_value = None
-                try:
-                    rhythm_float = float(raw_value)
-                except (TypeError, ValueError):
-                    return None
+                                target_syllables = None
+                        if min_syllable_threshold is not None and (target_syllables is None or target_syllables < min_syllable_threshold):
+                            return False
+                        if max_syllable_threshold is not None and (target_syllables is None or target_syllables > max_syllable_threshold):
+                            return False
+                    if max_line_distance is not None:
+                        distance_value = entry.get("distance")
+                        if distance_value is None or distance_value > max_line_distance:
+                            return False
 
-                entry["rhythm_score"] = rhythm_float
-                entry["stress_alignment"] = rhythm_float
-                profile_dict = _ensure_feature_profile(entry)
-                profile_dict.setdefault("stress_alignment", rhythm_float)
-                return rhythm_float
-
-            def _filter_entry(entry: Dict) -> bool:
-                if not _passes_min_confidence(entry):
-                    return False
-
-                entry_rhyme = _extract_rhyme_category(entry)
-                rhythm_score = _extract_rhythm_score(entry)
-
-                if not filters_active:
                     return True
 
-                if cultural_filters:
-                    sig = entry.get("cultural_sig")
-                    if sig is None or normalize_name(str(sig)) not in cultural_filters:
-                        return False
-                if genre_filters:
-                    genre_value = entry.get("genre")
-                    if genre_value is None or normalize_name(str(genre_value)) not in genre_filters:
-                        return False
-                if rhyme_type_filters:
-                    if not entry_rhyme or normalize_name(str(entry_rhyme)) not in rhyme_type_filters:
-                        return False
-                if bradley_filters:
-                    device_value = entry.get("bradley_device")
-                    if device_value is None and entry.get("feature_profile"):
-                        device_value = entry["feature_profile"].get("bradley_device")
-                    if device_value is None and entry.get("_bradley_device"):
-                        device_value = entry.get("_bradley_device")
-                    if (
-                        device_value is None
-                        or normalize_name(str(device_value)) not in bradley_filters
-                    ):
-                        return False
-                if min_rarity_threshold is not None:
+                def _rarity_value(entry: Dict) -> float:
                     rarity_metric = entry.get("rarity_score")
                     if rarity_metric is None:
                         rarity_metric = entry.get("cultural_rarity")
                     try:
-                        rarity_value = float(rarity_metric) if rarity_metric is not None else 0.0
+                        return float(rarity_metric)
                     except (TypeError, ValueError):
-                        rarity_value = 0.0
-                    if rarity_value < min_rarity_threshold:
-                        return False
-                if min_stress_threshold is not None:
-                    if rhythm_score is None or rhythm_score < min_stress_threshold:
-                        return False
-                if cadence_focus_normalized:
-                    prosody = entry.get("prosody_profile") or {}
-                    cadence_value = prosody.get("complexity_tag") if isinstance(prosody, dict) else None
-                    if cadence_value is None:
-                        cadence_value = entry.get("feature_profile", {}).get("complexity_tag")
-                    if not cadence_value or normalize_name(str(cadence_value)) != cadence_focus_normalized:
-                        return False
-                if require_internal:
-                    internal_value = entry.get("internal_rhyme_score")
-                    if internal_value is None and entry.get("feature_profile"):
-                        internal_value = entry["feature_profile"].get("internal_rhyme_score")
+                        return 0.0
+
+                def _confidence_value(entry: Dict) -> float:
+                    metric = entry.get("combined_score")
+                    if metric is None:
+                        metric = entry.get("confidence")
                     try:
-                        internal_float = float(internal_value) if internal_value is not None else 0.0
+                        return float(metric)
                     except (TypeError, ValueError):
-                        internal_float = 0.0
-                    if internal_float < 0.4:
-                        return False
-                if min_syllable_threshold is not None or max_syllable_threshold is not None:
-                    syllable_span = entry.get("syllable_span")
-                    if not syllable_span and entry.get("feature_profile"):
-                        syllable_span = entry["feature_profile"].get("syllable_span")
-                    if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
-                        try:
-                            target_syllables = int(syllable_span[1])
-                        except (TypeError, ValueError):
-                            target_syllables = None
-                    else:
-                        target_word = entry.get("target_word")
-                        try:
-                            estimator = getattr(self.phonetic_analyzer, "estimate_syllables", None)
-                            if callable(estimator):
-                                target_syllables = estimator(str(target_word)) if target_word else None
-                            else:
-                                target_syllables = self.phonetic_analyzer._count_syllables(str(target_word)) if target_word else None
-                        except Exception:
-                            target_syllables = None
-                    if min_syllable_threshold is not None and (target_syllables is None or target_syllables < min_syllable_threshold):
-                        return False
-                    if max_syllable_threshold is not None and (target_syllables is None or target_syllables > max_syllable_threshold):
-                        return False
-                if max_line_distance is not None:
-                    distance_value = entry.get("distance")
-                    if distance_value is None or distance_value > max_line_distance:
-                        return False
+                        return 0.0
 
-                return True
+                def _normalize_entry(entry: Dict, category_key: str) -> Dict:
+                    entry["result_source"] = category_key
+                    if not entry.get("source_phrase"):
+                        entry["source_phrase"] = entry.get("source_word", source_word)
+                    entry.setdefault("source_anchor", source_anchor_word)
+                    entry.setdefault("anchor_display", source_phonetic_profile.get("anchor_display"))
+                    entry.setdefault("phrase_prefix", source_phonetic_profile.get("phrase_prefix"))
+                    entry.setdefault("phrase_suffix", source_phonetic_profile.get("phrase_suffix"))
 
-            def _rarity_value(entry: Dict) -> float:
-                rarity_metric = entry.get("rarity_score")
-                if rarity_metric is None:
-                    rarity_metric = entry.get("cultural_rarity")
-                try:
-                    return float(rarity_metric)
-                except (TypeError, ValueError):
-                    return 0.0
+                    target_text = str(entry.get("target_word", ""))
+                    is_multi = bool(entry.get("is_multi_word"))
+                    if not is_multi and target_text:
+                        is_multi = " " in target_text.strip()
+                    entry["is_multi_word"] = is_multi
+                    if not entry.get("result_variant"):
+                        entry["result_variant"] = "multi_word" if is_multi else "single_word"
 
-            def _confidence_value(entry: Dict) -> float:
-                metric = entry.get("combined_score")
-                if metric is None:
-                    metric = entry.get("confidence")
-                try:
-                    return float(metric)
-                except (TypeError, ValueError):
-                    return 0.0
+                    if entry.get("pattern") and target_text:
+                        connector = " // " if is_multi else " / "
+                        source_value = str(entry.get("source_word", source_word))
+                        entry["pattern"] = f"{source_value}{connector}{target_text}"
+                    elif not entry.get("pattern") and target_text:
+                        connector = " // " if is_multi else " / "
+                        entry["pattern"] = f"{source_word}{connector}{target_text}"
+                    if entry.get("combined_score") is None and entry.get("confidence") is not None:
+                        entry["combined_score"] = entry["confidence"]
+                    if entry.get("confidence") is None and entry.get("combined_score") is not None:
+                        entry["confidence"] = entry["combined_score"]
 
-            def _normalize_entry(entry: Dict, category_key: str) -> Dict:
-                entry["result_source"] = category_key
-                if not entry.get("source_phrase"):
-                    entry["source_phrase"] = entry.get("source_word", source_word)
-                entry.setdefault("source_anchor", source_anchor_word)
-                entry.setdefault("anchor_display", source_phonetic_profile.get("anchor_display"))
-                entry.setdefault("phrase_prefix", source_phonetic_profile.get("phrase_prefix"))
-                entry.setdefault("phrase_suffix", source_phonetic_profile.get("phrase_suffix"))
-
-                target_text = str(entry.get("target_word", ""))
-                is_multi = bool(entry.get("is_multi_word"))
-                if not is_multi and target_text:
-                    is_multi = " " in target_text.strip()
-                entry["is_multi_word"] = is_multi
-                if not entry.get("result_variant"):
-                    entry["result_variant"] = "multi_word" if is_multi else "single_word"
-
-                if entry.get("pattern") and target_text:
-                    connector = " // " if is_multi else " / "
-                    source_value = str(entry.get("source_word", source_word))
-                    entry["pattern"] = f"{source_value}{connector}{target_text}"
-                elif not entry.get("pattern") and target_text:
-                    connector = " // " if is_multi else " / "
-                    entry["pattern"] = f"{source_word}{connector}{target_text}"
-                if entry.get("combined_score") is None and entry.get("confidence") is not None:
-                    entry["combined_score"] = entry["confidence"]
-                if entry.get("confidence") is None and entry.get("combined_score") is not None:
-                    entry["confidence"] = entry["combined_score"]
-
-                feature_profile = entry.get("feature_profile")
-                if feature_profile is None:
-                    entry["feature_profile"] = {}
-                elif not isinstance(feature_profile, dict):
-                    try:
-                        entry["feature_profile"] = dict(feature_profile)
-                    except Exception:
+                    feature_profile = entry.get("feature_profile")
+                    if feature_profile is None:
                         entry["feature_profile"] = {}
-                _sanitize_feature_profile(entry)
+                    elif not isinstance(feature_profile, dict):
+                        try:
+                            entry["feature_profile"] = dict(feature_profile)
+                        except Exception:
+                            entry["feature_profile"] = {}
+                    _sanitize_feature_profile(entry)
 
-                prosody_profile = entry.get("prosody_profile")
-                if prosody_profile is None:
-                    entry["prosody_profile"] = {}
+                    prosody_profile = entry.get("prosody_profile")
+                    if prosody_profile is None:
+                        entry["prosody_profile"] = {}
 
-                for field, default in {
-                    "rarity_score": None,
-                    "cultural_rarity": None,
-                    "phonetic_sim": None,
-                    "rhyme_type": None,
-                    "stress_alignment": None,
-                    "internal_rhyme_score": None,
-                    "cultural_context": None,
-                    "llm_weakness_type": None,
-                    "cultural_depth": None,
-                }.items():
-                    entry.setdefault(field, default)
+                    for field, default in {
+                        "rarity_score": None,
+                        "cultural_rarity": None,
+                        "phonetic_sim": None,
+                        "rhyme_type": None,
+                        "stress_alignment": None,
+                        "internal_rhyme_score": None,
+                        "cultural_context": None,
+                        "llm_weakness_type": None,
+                        "cultural_depth": None,
+                    }.items():
+                        entry.setdefault(field, default)
 
-                entry.setdefault("cultural_sig", None)
-                entry.setdefault("genre", None)
-                entry.setdefault("source_context", None)
-                entry.setdefault("target_context", None)
-                entry.setdefault("distance", None)
-                _ensure_target_phonetics(entry)
+                    entry.setdefault("cultural_sig", None)
+                    entry.setdefault("genre", None)
+                    entry.setdefault("source_context", None)
+                    entry.setdefault("target_context", None)
+                    entry.setdefault("distance", None)
+                    _ensure_target_phonetics(entry)
 
-                bradley_value = entry.pop("_bradley_device", None)
-                if bradley_value is not None:
-                    entry.setdefault("bradley_device", bradley_value)
+                    bradley_value = entry.pop("_bradley_device", None)
+                    if bradley_value is not None:
+                        entry.setdefault("bradley_device", bradley_value)
 
-                return entry
+                    return entry
 
-            def _process_entries(entries: List[Dict], category_key: str) -> List[Dict]:
-                if not entries:
-                    return []
+                def _process_entries(entries: List[Dict], category_key: str) -> List[Dict]:
+                    if not entries:
+                        return []
 
-                if category_key == "rap_db":
-                    grouped: "OrderedDict[Tuple[str, str], Dict[str, Any]]" = OrderedDict()
+                    if category_key == "rap_db":
+                        grouped: "OrderedDict[Tuple[str, str], Dict[str, Any]]" = OrderedDict()
+                        for entry in entries:
+                            normalized_entry = _normalize_entry(entry, category_key)
+                            if not _filter_entry(normalized_entry):
+                                continue
+
+                            artist_key = str(normalized_entry.get("artist") or "").strip().lower()
+                            song_key = str(normalized_entry.get("song") or "").strip().lower()
+                            group_key = (artist_key, song_key)
+                            group = grouped.get(group_key)
+                            if group is None:
+                                group = {
+                                    "artist": normalized_entry.get("artist"),
+                                    "song": normalized_entry.get("song"),
+                                    "genre": normalized_entry.get("genre"),
+                                    "cultural_sig": normalized_entry.get("cultural_sig"),
+                                    "cultural_context": normalized_entry.get("cultural_context"),
+                                    "result_source": category_key,
+                                    "grouped_targets": [],
+                                    "max_confidence": 0.0,
+                                    "max_phonetic_sim": 0.0,
+                                    "max_cultural_rarity": None,
+                                    "max_rarity_score": None,
+                                    "is_multi_word": False,
+                                    "pattern": None,
+                                    "source_context": None,
+                                    "target_context": None,
+                                    "prosody_profile": None,
+                                    "_rhyme_types": set(),
+                                }
+                                grouped[group_key] = group
+                            else:
+                                if not group.get("genre") and normalized_entry.get("genre"):
+                                    group["genre"] = normalized_entry.get("genre")
+                                if not group.get("cultural_sig") and normalized_entry.get("cultural_sig"):
+                                    group["cultural_sig"] = normalized_entry.get("cultural_sig")
+                                if not group.get("cultural_context") and normalized_entry.get("cultural_context"):
+                                    group["cultural_context"] = normalized_entry.get("cultural_context")
+
+                            target_key = (
+                                str(normalized_entry.get("target_word") or "").strip().lower(),
+                                str(normalized_entry.get("pattern") or "").strip().lower(),
+                            )
+                            seen_targets = group.setdefault("_seen_targets", set())
+                            if target_key in seen_targets:
+                                continue
+                            seen_targets.add(target_key)
+
+                            target_payload = dict(normalized_entry)
+                            target_payload.pop("source_word", None)
+
+                            group["grouped_targets"].append(target_payload)
+                            group["target_word"] = group["grouped_targets"][0].get("target_word")
+                            if group.get("pattern") is None and target_payload.get("pattern"):
+                                group["pattern"] = target_payload.get("pattern")
+                            if group.get("source_context") is None and target_payload.get("source_context"):
+                                group["source_context"] = target_payload.get("source_context")
+                            if group.get("target_context") is None and target_payload.get("target_context"):
+                                group["target_context"] = target_payload.get("target_context")
+                            if target_payload.get("is_multi_word"):
+                                group["is_multi_word"] = True
+                            if group.get("prosody_profile") is None and target_payload.get("prosody_profile"):
+                                group["prosody_profile"] = target_payload.get("prosody_profile")
+                            rhythm_metric = target_payload.get("rhythm_score")
+                            if rhythm_metric is None:
+                                rhythm_metric = target_payload.get("stress_alignment")
+                            try:
+                                rhythm_float = float(rhythm_metric)
+                            except (TypeError, ValueError):
+                                rhythm_float = None
+                            if rhythm_float is not None:
+                                current_rhythm = group.get("rhythm_score")
+                                if current_rhythm is None or rhythm_float > float(current_rhythm):
+                                    group["rhythm_score"] = rhythm_float
+                                    group["stress_alignment"] = rhythm_float
+                            group["max_confidence"] = max(
+                                group["max_confidence"],
+                                _confidence_value(target_payload),
+                            )
+                            group["max_phonetic_sim"] = max(
+                                group["max_phonetic_sim"],
+                                float(target_payload.get("phonetic_sim") or 0.0),
+                            )
+                            rarity_metric = target_payload.get("cultural_rarity")
+                            if rarity_metric is None:
+                                rarity_metric = target_payload.get("rarity_score")
+                            try:
+                                rarity_float = float(rarity_metric)
+                            except (TypeError, ValueError):
+                                rarity_float = None
+                            if rarity_float is not None:
+                                current_cultural = group.get("max_cultural_rarity")
+                                if current_cultural is None or rarity_float > current_cultural:
+                                    group["max_cultural_rarity"] = rarity_float
+                            rarity_score_metric = target_payload.get("rarity_score")
+                            try:
+                                rarity_score_float = float(rarity_score_metric)
+                            except (TypeError, ValueError):
+                                rarity_score_float = None
+                            if rarity_score_float is not None:
+                                current_score = group.get("max_rarity_score")
+                                if current_score is None or rarity_score_float > current_score:
+                                    group["max_rarity_score"] = rarity_score_float
+                            target_rhyme_type = target_payload.get("rhyme_type")
+                            if target_rhyme_type:
+                                rhyme_set = group.setdefault("_rhyme_types", set())
+                                rhyme_set.add(target_rhyme_type)
+
+                        processed_groups: List[Dict[str, Any]] = []
+                        for group in grouped.values():
+                            targets = group.get("grouped_targets") or []
+                            if not targets:
+                                continue
+                            group["group_size"] = len(targets)
+                            group["confidence"] = group.get("max_confidence")
+                            group["combined_score"] = group.get("max_confidence")
+                            group["phonetic_sim"] = group.get("max_phonetic_sim")
+                            if group.get("max_cultural_rarity") is not None:
+                                group["cultural_rarity"] = group.get("max_cultural_rarity")
+                            if group.get("max_rarity_score") is not None:
+                                group["rarity_score"] = group.get("max_rarity_score")
+                            rhyme_types = group.pop("_rhyme_types", set())
+                            if len(rhyme_types) == 1:
+                                group["rhyme_type"] = next(iter(rhyme_types))
+                            elif not rhyme_types:
+                                group["rhyme_type"] = group.get("rhyme_type")
+                            else:
+                                group["rhyme_type"] = None
+                            group.pop("_seen_targets", None)
+                            group.pop("max_cultural_rarity", None)
+                            group.pop("max_rarity_score", None)
+                            processed_groups.append(group)
+
+                        return processed_groups
+
+                    processed: List[Dict] = []
+                    seen_pairs = set()
                     for entry in entries:
+                        target_value = entry.get("target_word")
+                        if not target_value:
+                            continue
+
+                        source_value = entry.get("source_word", source_word)
+                        pair = (
+                            str(source_value).strip().lower(),
+                            str(target_value).strip().lower(),
+                        )
+                        if pair in seen_pairs:
+                            continue
+                        seen_pairs.add(pair)
+
                         normalized_entry = _normalize_entry(entry, category_key)
                         if not _filter_entry(normalized_entry):
                             continue
 
-                        artist_key = str(normalized_entry.get("artist") or "").strip().lower()
-                        song_key = str(normalized_entry.get("song") or "").strip().lower()
-                        group_key = (artist_key, song_key)
-                        group = grouped.get(group_key)
-                        if group is None:
-                            group = {
-                                "artist": normalized_entry.get("artist"),
-                                "song": normalized_entry.get("song"),
-                                "genre": normalized_entry.get("genre"),
-                                "cultural_sig": normalized_entry.get("cultural_sig"),
-                                "cultural_context": normalized_entry.get("cultural_context"),
-                                "result_source": category_key,
-                                "grouped_targets": [],
-                                "max_confidence": 0.0,
-                                "max_phonetic_sim": 0.0,
-                                "max_cultural_rarity": None,
-                                "max_rarity_score": None,
-                                "is_multi_word": False,
-                                "pattern": None,
-                                "source_context": None,
-                                "target_context": None,
-                                "prosody_profile": None,
-                                "_rhyme_types": set(),
-                            }
-                            grouped[group_key] = group
-                        else:
-                            if not group.get("genre") and normalized_entry.get("genre"):
-                                group["genre"] = normalized_entry.get("genre")
-                            if not group.get("cultural_sig") and normalized_entry.get("cultural_sig"):
-                                group["cultural_sig"] = normalized_entry.get("cultural_sig")
-                            if not group.get("cultural_context") and normalized_entry.get("cultural_context"):
-                                group["cultural_context"] = normalized_entry.get("cultural_context")
+                        normalized_entry.pop("source_word", None)
+                        processed.append(normalized_entry)
 
-                        target_key = (
-                            str(normalized_entry.get("target_word") or "").strip().lower(),
-                            str(normalized_entry.get("pattern") or "").strip().lower(),
-                        )
-                        seen_targets = group.setdefault("_seen_targets", set())
-                        if target_key in seen_targets:
-                            continue
-                        seen_targets.add(target_key)
-
-                        target_payload = dict(normalized_entry)
-                        target_payload.pop("source_word", None)
-
-                        group["grouped_targets"].append(target_payload)
-                        group["target_word"] = group["grouped_targets"][0].get("target_word")
-                        if group.get("pattern") is None and target_payload.get("pattern"):
-                            group["pattern"] = target_payload.get("pattern")
-                        if group.get("source_context") is None and target_payload.get("source_context"):
-                            group["source_context"] = target_payload.get("source_context")
-                        if group.get("target_context") is None and target_payload.get("target_context"):
-                            group["target_context"] = target_payload.get("target_context")
-                        if target_payload.get("is_multi_word"):
-                            group["is_multi_word"] = True
-                        if group.get("prosody_profile") is None and target_payload.get("prosody_profile"):
-                            group["prosody_profile"] = target_payload.get("prosody_profile")
-                        rhythm_metric = target_payload.get("rhythm_score")
-                        if rhythm_metric is None:
-                            rhythm_metric = target_payload.get("stress_alignment")
-                        try:
-                            rhythm_float = float(rhythm_metric)
-                        except (TypeError, ValueError):
-                            rhythm_float = None
-                        if rhythm_float is not None:
-                            current_rhythm = group.get("rhythm_score")
-                            if current_rhythm is None or rhythm_float > float(current_rhythm):
-                                group["rhythm_score"] = rhythm_float
-                                group["stress_alignment"] = rhythm_float
-                        group["max_confidence"] = max(
-                            group["max_confidence"],
-                            _confidence_value(target_payload),
-                        )
-                        group["max_phonetic_sim"] = max(
-                            group["max_phonetic_sim"],
-                            float(target_payload.get("phonetic_sim") or 0.0),
-                        )
-                        rarity_metric = target_payload.get("cultural_rarity")
-                        if rarity_metric is None:
-                            rarity_metric = target_payload.get("rarity_score")
-                        try:
-                            rarity_float = float(rarity_metric)
-                        except (TypeError, ValueError):
-                            rarity_float = None
-                        if rarity_float is not None:
-                            current_cultural = group.get("max_cultural_rarity")
-                            if current_cultural is None or rarity_float > current_cultural:
-                                group["max_cultural_rarity"] = rarity_float
-                        rarity_score_metric = target_payload.get("rarity_score")
-                        try:
-                            rarity_score_float = float(rarity_score_metric)
-                        except (TypeError, ValueError):
-                            rarity_score_float = None
-                        if rarity_score_float is not None:
-                            current_score = group.get("max_rarity_score")
-                            if current_score is None or rarity_score_float > current_score:
-                                group["max_rarity_score"] = rarity_score_float
-                        target_rhyme_type = target_payload.get("rhyme_type")
-                        if target_rhyme_type:
-                            rhyme_set = group.setdefault("_rhyme_types", set())
-                            rhyme_set.add(target_rhyme_type)
-
-                    processed_groups: List[Dict[str, Any]] = []
-                    for group in grouped.values():
-                        targets = group.get("grouped_targets") or []
-                        if not targets:
-                            continue
-                        group["group_size"] = len(targets)
-                        group["confidence"] = group.get("max_confidence")
-                        group["combined_score"] = group.get("max_confidence")
-                        group["phonetic_sim"] = group.get("max_phonetic_sim")
-                        if group.get("max_cultural_rarity") is not None:
-                            group["cultural_rarity"] = group.get("max_cultural_rarity")
-                        if group.get("max_rarity_score") is not None:
-                            group["rarity_score"] = group.get("max_rarity_score")
-                        rhyme_types = group.pop("_rhyme_types", set())
-                        if len(rhyme_types) == 1:
-                            group["rhyme_type"] = next(iter(rhyme_types))
-                        elif not rhyme_types:
-                            group["rhyme_type"] = group.get("rhyme_type")
-                        else:
-                            group["rhyme_type"] = None
-                        group.pop("_seen_targets", None)
-                        group.pop("max_cultural_rarity", None)
-                        group.pop("max_rarity_score", None)
-                        processed_groups.append(group)
-
-                    return processed_groups
-
-                processed: List[Dict] = []
-                seen_pairs = set()
-                for entry in entries:
-                    target_value = entry.get("target_word")
-                    if not target_value:
-                        continue
-
-                    source_value = entry.get("source_word", source_word)
-                    pair = (
-                        str(source_value).strip().lower(),
-                        str(target_value).strip().lower(),
+                    processed.sort(
+                        key=lambda entry: (
+                            _rarity_value(entry),
+                            _confidence_value(entry),
+                        ),
+                        reverse=True,
                     )
-                    if pair in seen_pairs:
-                        continue
-                    seen_pairs.add(pair)
 
-                    normalized_entry = _normalize_entry(entry, category_key)
-                    if not _filter_entry(normalized_entry):
-                        continue
+                    if limit is None:
+                        return processed
 
-                    normalized_entry.pop("source_word", None)
-                    processed.append(normalized_entry)
+                    try:
+                        capped_limit = max(int(limit), 0)
+                    except (TypeError, ValueError):
+                        capped_limit = len(processed)
 
-                processed.sort(
-                    key=lambda entry: (
-                        _rarity_value(entry),
-                        _confidence_value(entry),
-                    ),
-                    reverse=True,
-                )
+                    return processed[:capped_limit]
 
-                if limit is None:
-                    return processed
+                response = {
+                    "source_profile": source_phonetic_profile,
+                    "cmu": _process_entries(phonetic_entries if include_phonetic else [], "cmu"),
+                    "anti_llm": _process_entries(anti_llm_entries if include_anti_llm else [], "anti_llm"),
+                    "rap_db": _process_entries(cultural_entries if include_cultural else [], "rap_db"),
+                }
 
-                try:
-                    capped_limit = max(int(limit), 0)
-                except (TypeError, ValueError):
-                    capped_limit = len(processed)
+                duration_ms = (perf_counter() - start_time) * 1000.0
+                summary_payload = {
+                    "source_word": source_word,
+                    "duration_ms": round(duration_ms, 3),
+                    "cmu_count": len(response.get("cmu", [])),
+                    "anti_llm_count": len(response.get("anti_llm", [])),
+                    "rap_db_count": len(response.get("rap_db", [])),
+                }
+                logger.info("search.complete %s", json.dumps(summary_payload, sort_keys=True))
+                if total_span is not None:
+                    try:
+                        total_span.set_attribute("results.cmu", summary_payload["cmu_count"])
+                        total_span.set_attribute(
+                            "results.anti_llm", summary_payload["anti_llm_count"]
+                        )
+                        total_span.set_attribute("results.rap_db", summary_payload["rap_db_count"])
+                        total_span.set_attribute("filters.active", filters_active)
+                    except Exception:
+                        logger.debug("Failed to annotate search span", exc_info=True)
 
-                return processed[:capped_limit]
-
-            return {
-                "source_profile": source_phonetic_profile,
-                "cmu": _process_entries(phonetic_entries if include_phonetic else [], "cmu"),
-                "anti_llm": _process_entries(anti_llm_entries if include_anti_llm else [], "anti_llm"),
-                "rap_db": _process_entries(cultural_entries if include_cultural else [], "rap_db"),
-            }
+                return response
+            finally:
+                total_timer.__exit__(None, None, None)
 
 
 
@@ -1943,4 +2143,3 @@ class SearchService:
             lines.append("")
 
         return "\n".join(lines).strip() + "\n"
-

--- a/rhyme_rarity/core/analyzer.py
+++ b/rhyme_rarity/core/analyzer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import difflib
+import logging
 import math
 import re
 from collections import Counter
@@ -20,6 +21,9 @@ from .feature_profile import (
     pronouncing,
 )
 from .rarity_map import DEFAULT_RARITY_MAP, WordRarityMap
+
+
+logger = logging.getLogger(__name__)
 
 RARITY_SIMILARITY_WEIGHT: float = 0.65
 RARITY_NOVELTY_WEIGHT: float = 0.35
@@ -42,7 +46,13 @@ class EnhancedPhoneticAnalyzer:
         self.consonant_groups = self._initialize_consonant_groups()
         self.phonetic_weights = self._initialize_phonetic_weights()
 
-        print("📊 Enhanced Core Phonetic Analyzer initialized")
+        logger.info(
+            "analyzer.initialized",
+            extra={
+                "cmu_dict": getattr(self.cmu_loader, "dict_path", None),
+                "rarity_map": type(self.rarity_map).__name__,
+            },
+        )
     
     def _initialize_vowel_groups(self) -> Dict[str, List[str]]:
         """Initialize vowel sound groupings for phonetic analysis"""

--- a/rhyme_rarity/utils/observability.py
+++ b/rhyme_rarity/utils/observability.py
@@ -1,0 +1,189 @@
+"""Utility helpers for logging, metrics, and tracing.
+
+This module centralises optional observability primitives so other packages
+can instrument their behaviour without needing to guard every import.  All
+helpers degrade gracefully when the optional dependencies are unavailable so
+the core application can continue to function in constrained environments.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from time import perf_counter
+from typing import Any, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - exercised indirectly in environments with the deps
+    from prometheus_client import Counter, Gauge, Histogram
+except Exception:  # pragma: no cover - safety net for partial installations
+    Counter = Gauge = Histogram = None  # type: ignore[assignment]
+
+
+class _NoopMetric:
+    """Fallback metric implementation used when prometheus_client is absent."""
+
+    def labels(self, *args: Any, **kwargs: Any) -> "_NoopMetric":
+        return self
+
+    def inc(self, amount: float = 1.0) -> None:
+        return None
+
+    def observe(self, value: float) -> None:
+        return None
+
+    def set(self, value: float) -> None:
+        return None
+
+
+def _build_metric(factory: Optional[Any], *args: Any, **kwargs: Any) -> Any:
+    if factory is None:
+        return _NoopMetric()
+    try:
+        return factory(*args, **kwargs)
+    except Exception:  # pragma: no cover - defensive guardrail
+        logger.exception("Failed to construct metric", extra={"metric_args": args})
+        return _NoopMetric()
+
+
+SEARCH_REQUESTS_TOTAL = _build_metric(
+    Counter,
+    "search_requests_total",
+    "Number of rhyme searches routed to each engine.",
+    labelnames=("source", "filters"),
+)
+
+SEARCH_LATENCY_SECONDS = _build_metric(
+    Histogram,
+    "search_latency_seconds",
+    "Latency distribution for rhyme searches by stage.",
+    labelnames=("stage",),
+)
+
+SEARCH_ERRORS_TOTAL = _build_metric(
+    Counter,
+    "search_errors_total",
+    "Count of handled errors while serving rhyme searches.",
+    labelnames=("stage",),
+)
+
+CACHE_HIT_RATIO = _build_metric(
+    Gauge,
+    "cache_hit_ratio",
+    "Rolling ratio of cache hits for rhyme search helpers.",
+    labelnames=("cache",),
+)
+
+DATABASE_INITIALIZATION_TOTAL = _build_metric(
+    Counter,
+    "database_initialization_total",
+    "Number of times the application prepared the patterns database.",
+    labelnames=("mode",),
+)
+
+RARITY_REFRESH_FAILURES_TOTAL = _build_metric(
+    Counter,
+    "rarity_refresh_failures_total",
+    "Count of failed rarity map refresh attempts.",
+)
+
+
+try:  # pragma: no cover - only executed when opentelemetry is available
+    from opentelemetry import trace
+except Exception:  # pragma: no cover - keep tracing optional
+    trace = None  # type: ignore[assignment]
+
+
+def _get_tracer() -> Optional[Any]:
+    if trace is None:
+        return None
+    try:
+        return trace.get_tracer("rhyme_rarity")
+    except Exception:  # pragma: no cover - defensive guardrail
+        logger.exception("Failed to acquire OpenTelemetry tracer")
+        return None
+
+
+@contextmanager
+def traced_span(name: str, **attributes: Any) -> Iterator[Optional[Any]]:
+    """Context manager that starts an OpenTelemetry span when available."""
+
+    tracer = _get_tracer()
+    if tracer is None:
+        yield None
+        return
+
+    with tracer.start_as_current_span(name) as span:  # pragma: no cover - thin
+        for key, value in attributes.items():
+            try:
+                span.set_attribute(key, value)
+            except Exception:
+                logger.debug("Failed to set span attribute", exc_info=True)
+        yield span
+
+
+@contextmanager
+def observe_stage_latency(stage: str, **attributes: Any) -> Iterator[Optional[Any]]:
+    """Record execution time for a stage and attach tracing metadata."""
+
+    start = perf_counter()
+    span_name = attributes.pop("span_name", stage)
+    with traced_span(span_name, stage=stage, **attributes) as span:
+        yield span
+
+    duration = perf_counter() - start
+    SEARCH_LATENCY_SECONDS.labels(stage=stage).observe(duration)
+    if span is not None:
+        try:
+            span.set_attribute("duration_ms", duration * 1000.0)
+        except Exception:
+            logger.debug("Failed to annotate span duration", exc_info=True)
+
+
+def record_search_request(source: str, filters_active: bool) -> None:
+    label = "active" if filters_active else "none"
+    SEARCH_REQUESTS_TOTAL.labels(source=source, filters=label).inc()
+
+
+def record_search_error(stage: str, **metadata: Any) -> None:
+    SEARCH_ERRORS_TOTAL.labels(stage=stage).inc()
+    if metadata:
+        logger.debug("search.error", extra={"stage": stage, **metadata})
+
+
+def update_cache_hit_ratio(cache: str, hits: int, lookups: int) -> None:
+    ratio = 0.0
+    if lookups > 0:
+        ratio = max(0.0, min(1.0, hits / float(lookups)))
+    CACHE_HIT_RATIO.labels(cache=cache).set(ratio)
+
+
+def record_database_initialization(mode: str, **metadata: Any) -> None:
+    DATABASE_INITIALIZATION_TOTAL.labels(mode=mode).inc()
+    if metadata:
+        logger.debug("database.initialization", extra={"mode": mode, **metadata})
+
+
+def record_rarity_refresh_failure(**metadata: Any) -> None:
+    RARITY_REFRESH_FAILURES_TOTAL.inc()
+    if metadata:
+        logger.debug("rarity.refresh_failure", extra=metadata)
+
+
+__all__ = [
+    "CACHE_HIT_RATIO",
+    "DATABASE_INITIALIZATION_TOTAL",
+    "RARITY_REFRESH_FAILURES_TOTAL",
+    "SEARCH_ERRORS_TOTAL",
+    "SEARCH_LATENCY_SECONDS",
+    "SEARCH_REQUESTS_TOTAL",
+    "observe_stage_latency",
+    "record_database_initialization",
+    "record_rarity_refresh_failure",
+    "record_search_error",
+    "record_search_request",
+    "traced_span",
+    "update_cache_hit_ratio",
+]
+


### PR DESCRIPTION
## Summary
- add reusable observability helpers that gracefully wrap Prometheus metrics and OpenTelemetry spans
- instrument the search pipeline caches, request flow, and fallbacks with structured logging, metrics, and tracing attributes
- promote structured initialization/error logging across the app facade, database repository, analyzer, cultural engine, and anti-LLM engine

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c680a3e48322b45ca5595327dabf