### PR TITLE
Implement caching across anti-LLM engine

### DIFF
--- a/anti_llm/dataclasses.py
+++ b/anti_llm/dataclasses.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict, Iterable, Set, Tuple
 
 
 @dataclass
@@ -33,9 +33,32 @@ class SeedCandidate:
     signatures: Set[str] = field(default_factory=set)
     feature_profile: Dict[str, Any] = field(default_factory=dict)
     prosody_profile: Dict[str, Any] = field(default_factory=dict)
+    _fingerprint_cache: Set[str] = field(default_factory=set, init=False, repr=False)
+    _suffix_cache: Set[str] = field(default_factory=set, init=False, repr=False)
+    _signature_hint_cache: Set[str] = field(default_factory=set, init=False, repr=False)
 
     def normalized(self) -> str:
         return self.word.lower().strip()
+
+    # Cached derivative helpers -------------------------------------------------
+
+    def cache_fingerprint(self, fingerprint: Iterable[str]) -> None:
+        self._fingerprint_cache = {str(value) for value in fingerprint if value}
+
+    def cached_fingerprint(self) -> Set[str]:
+        return set(self._fingerprint_cache)
+
+    def cache_suffixes(self, suffixes: Iterable[str]) -> None:
+        self._suffix_cache = {str(value) for value in suffixes if value}
+
+    def cached_suffixes(self) -> Set[str]:
+        return set(self._suffix_cache)
+
+    def cache_signature_hints(self, hints: Iterable[str]) -> None:
+        self._signature_hint_cache = {str(value) for value in hints if value}
+
+    def cached_signature_hints(self) -> Set[str]:
+        return set(self._signature_hint_cache)
 
 
 __all__ = ["AntiLLMPattern", "SeedCandidate"]

--- a/anti_llm/engine.py
+++ b/anti_llm/engine.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
 
 from rhyme_rarity.utils.profile import normalize_profile_dict
 from rhyme_rarity.utils.syllables import estimate_syllable_count
@@ -28,6 +28,9 @@ from .strategies import (
     initialize_llm_weaknesses,
     initialize_rarity_multipliers,
 )
+
+
+_PROFILE_CACHE_MISS = object()
 
 
 class AntiLLMRhymeEngine:
@@ -67,6 +70,23 @@ class AntiLLMRhymeEngine:
         self._seed_resources_initialized = False
         self._seed_analyzer = None
         self._cmu_seed_fn = None
+        self._normalized_seed_cache: Dict[Any, Tuple[SeedCandidate, ...]] = {}
+        self._seed_context_cache: Dict[
+            Tuple[str, Any, frozenset, frozenset],
+            Tuple[Tuple[SeedCandidate, ...], frozenset, frozenset],
+        ] = {}
+        self._rarity_cache: Dict[str, float] = {}
+        self._fingerprint_cache: Dict[str, Tuple[str, ...]] = {}
+        self._suffix_cache: Dict[str, Tuple[str, ...]] = {}
+        self._phonological_complexity_cache: Dict[Tuple[str, str], float] = {}
+        self._syllable_complexity_cache: Dict[str, float] = {}
+        self._profile_cache: Dict[Tuple[str, str], Any] = {}
+        self._seed_neighbor_cache: Dict[Tuple[str, int], Tuple[Dict[str, Any], ...]] = {}
+        self._suffix_match_cache: Dict[Tuple[str, int], Tuple[Dict[str, Any], ...]] = {}
+        self._strategy_row_cache: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._cultural_multiplier_cache: Dict[str, float] = {}
+        self._pattern_cache: Dict[str, List[AntiLLMPattern]] = {}
+        self._current_source_key: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Dependency management
@@ -100,44 +120,317 @@ class AntiLLMRhymeEngine:
         return fallback
 
     def _get_word_rarity(self, word: str) -> float:
+        normalized = str(word or "").lower().strip()
+        if not normalized:
+            return 0.0
+
+        cached = self._rarity_cache.get(normalized)
+        if cached is not None:
+            return cached
+
         rarity_map = self._get_rarity_map()
         try:
-            rarity = rarity_map.get_rarity(word)
+            rarity = rarity_map.get_rarity(normalized)
         except Exception:
             from rhyme_rarity.core import DEFAULT_RARITY_MAP
 
-            rarity = DEFAULT_RARITY_MAP.get_rarity(word)
+            rarity = DEFAULT_RARITY_MAP.get_rarity(normalized)
 
         try:
-            return float(rarity)
+            rarity_value = float(rarity)
         except (TypeError, ValueError):
             from rhyme_rarity.core import DEFAULT_RARITY_MAP
 
-            return float(DEFAULT_RARITY_MAP.get_rarity(word))
+            rarity_value = float(DEFAULT_RARITY_MAP.get_rarity(normalized))
+
+        self._rarity_cache[normalized] = rarity_value
+        return rarity_value
 
     def _safe_float(self, value: Any, default: float = 0.0) -> float:
         return safe_float(value, default)
 
-    def _normalize_seed_candidates(self, module1_seeds: Optional[List[Any]]) -> List[SeedCandidate]:
-        return normalize_seed_candidates(
+    def _freeze_for_cache(self, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return tuple(
+                (key, self._freeze_for_cache(val)) for key, val in sorted(value.items())
+            )
+        if isinstance(value, (list, tuple, set)):
+            return tuple(self._freeze_for_cache(item) for item in value)
+        if isinstance(value, (str, int, float, bool)):
+            return value
+        return repr(value)
+
+    def _prepare_source_context(self, source_word: str) -> None:
+        if self._current_source_key == source_word:
+            return
+
+        self._current_source_key = source_word
+
+        self._strategy_row_cache = {
+            key: value
+            for key, value in self._strategy_row_cache.items()
+            if key[1] == source_word
+        }
+
+        cached_patterns = self._pattern_cache.get(source_word)
+        self._pattern_cache = {
+            source_word: list(cached_patterns) if cached_patterns else []
+        }
+
+    def _cached_normalize_seeds(
+        self, module1_seeds: Optional[List[Any]]
+    ) -> List[SeedCandidate]:
+        key = self._freeze_for_cache(module1_seeds) if module1_seeds else ()
+        cached = self._normalized_seed_cache.get(key)
+        if cached is not None:
+            return [seed for seed in cached]
+
+        normalized = normalize_seed_candidates(
             module1_seeds,
             self._get_word_rarity,
             value_sanitizer=self._safe_float,
         )
+        self._normalized_seed_cache[key] = tuple(normalized)
+        return normalized
+
+    def _seed_fingerprint(self, seed: SeedCandidate) -> Set[str]:
+        cached = seed.cached_fingerprint()
+        if cached:
+            return set(cached)
+
+        fingerprint = self._get_phonetic_fingerprint(seed.word)
+        seed.cache_fingerprint(fingerprint)
+        return set(fingerprint)
+
+    def _seed_suffixes(self, seed: SeedCandidate) -> Set[str]:
+        cached = seed.cached_suffixes()
+        if cached:
+            return set(cached)
+
+        suffixes = self._extract_suffixes(seed.word)
+        seed.cache_suffixes(suffixes)
+        return set(suffixes)
+
+    def _seed_signature_hints(self, seed: SeedCandidate) -> Set[str]:
+        cached = seed.cached_signature_hints()
+        if cached:
+            return set(cached)
+
+        hints = set(seed.signatures)
+        hints.update(self._seed_fingerprint(seed))
+
+        feature_profile = seed.feature_profile or {}
+        stress_hint = feature_profile.get("stress_alignment")
+        if isinstance(stress_hint, (int, float)):
+            hints.add(f"stress::{round(float(stress_hint), 2)}")
+
+        device_hint = feature_profile.get("bradley_device")
+        if device_hint:
+            hints.add(f"device::{str(device_hint).lower()}")
+
+        seed.cache_signature_hints(hints)
+        return hints
+
+    def _prepare_seed_context(
+        self,
+        source_word: str,
+        module1_seeds: Optional[List[Any]],
+        seed_signatures: Optional[Set[str]],
+        delivered_words: Optional[Set[str]],
+    ) -> Tuple[List[SeedCandidate], Set[str], Set[str]]:
+        normalized_seed_key = self._freeze_for_cache(module1_seeds) if module1_seeds else ()
+        provided_signatures = frozenset(
+            {str(sig).strip() for sig in seed_signatures if sig}
+            if seed_signatures
+            else set()
+        )
+        delivered_key = frozenset(
+            {str(word).lower().strip() for word in delivered_words if word}
+            if delivered_words
+            else set()
+        )
+
+        cache_key = (source_word, normalized_seed_key, provided_signatures, delivered_key)
+        cached = self._seed_context_cache.get(cache_key)
+        if cached is not None:
+            cached_seeds, cached_hints, cached_delivered = cached
+            return (
+                [seed for seed in cached_seeds],
+                set(cached_hints),
+                set(cached_delivered),
+            )
+
+        seeds = self._cached_normalize_seeds(module1_seeds)
+        signature_hints: Set[str] = set(provided_signatures)
+        delivered_set: Set[str] = set(delivered_key)
+        delivered_set.add(source_word)
+
+        for seed in seeds:
+            signature_hints.update(self._seed_signature_hints(seed))
+            delivered_set.add(seed.normalized())
+            self._seed_suffixes(seed)
+
+        cache_value = (
+            tuple(seeds),
+            frozenset(signature_hints),
+            frozenset(delivered_set),
+        )
+        self._seed_context_cache[cache_key] = cache_value
+        return seeds, signature_hints, delivered_set
+
+    def _prefetch_rarities(self, words: Iterable[str]) -> Dict[str, float]:
+        rarities: Dict[str, float] = {}
+        for word in words:
+            normalized = str(word or "").lower().strip()
+            if not normalized:
+                continue
+            rarities[normalized] = self._get_word_rarity(normalized)
+        return rarities
+
+    def _prefetch_cultural_multipliers(self, labels: Iterable[str]) -> Dict[str, float]:
+        multipliers: Dict[str, float] = {}
+        for label in labels:
+            normalized = str(label or "").strip()
+            if normalized not in self._cultural_multiplier_cache:
+                self._cultural_multiplier_cache[normalized] = self.cultural_depth_weights.get(
+                    normalized, 1.0
+                )
+            multipliers[normalized] = self._cultural_multiplier_cache[normalized]
+        return multipliers
+
+    def _fetch_strategy_rows(
+        self,
+        strategy_name: str,
+        source_word: str,
+        limit: int,
+        fetcher: Callable[[str, int], List[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
+        cache_key = (strategy_name, source_word)
+        cached = self._strategy_row_cache.get(cache_key)
+        if cached is not None and cached.get("limit", 0) >= limit:
+            rows: Tuple[Dict[str, Any], ...] = cached["rows"]
+        else:
+            rows_list = fetcher(source_word, limit)
+            rows = tuple(dict(row) for row in rows_list)
+            self._strategy_row_cache[cache_key] = {"limit": limit, "rows": rows}
+        return [row.copy() for row in rows]
+
+    def _build_profile_payload(self, profile_dict: Dict[str, Any]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "feature_profile": dict(profile_dict),
+            "bradley_device": None,
+            "syllable_span": None,
+            "stress_alignment": None,
+            "rarity_multiplier": 1.0,
+            "prosody_profile": {},
+        }
+
+        bradley = profile_dict.get("bradley_device")
+        if isinstance(bradley, str) and bradley:
+            payload["bradley_device"] = bradley
+
+        span_candidate = profile_dict.get("syllable_span")
+        span_tuple: Optional[Tuple[int, int]] = None
+        if isinstance(span_candidate, (list, tuple)) and len(span_candidate) == 2:
+            try:
+                span_tuple = (int(span_candidate[0]), int(span_candidate[1]))
+            except (TypeError, ValueError):
+                span_tuple = None
+        if span_tuple:
+            payload["syllable_span"] = span_tuple
+
+        stress_alignment = profile_dict.get("stress_alignment")
+        if isinstance(stress_alignment, (int, float)):
+            payload["stress_alignment"] = float(stress_alignment)
+
+        internal_score = profile_dict.get("internal_rhyme_score")
+        if isinstance(internal_score, (int, float)):
+            payload["rarity_multiplier"] = 1.0 + max(0.0, float(internal_score)) * 0.15
+
+        payload["prosody_profile"] = {
+            "complexity_tag": "dense" if span_tuple and max(span_tuple) >= 3 else "steady",
+            "stress_alignment": payload["stress_alignment"],
+            "assonance": profile_dict.get("assonance_score"),
+            "consonance": profile_dict.get("consonance_score"),
+        }
+
+        return payload
+
+    def _apply_profile_data(self, pattern: AntiLLMPattern, payload: Dict[str, Any]) -> None:
+        pattern.feature_profile = dict(payload.get("feature_profile", {}))
+
+        rarity_multiplier = float(payload.get("rarity_multiplier", 1.0))
+        if rarity_multiplier != 1.0:
+            pattern.rarity_score *= rarity_multiplier
+
+        bradley_device = payload.get("bradley_device")
+        if isinstance(bradley_device, str) and bradley_device:
+            pattern.bradley_device = bradley_device
+
+        syllable_span = payload.get("syllable_span")
+        if isinstance(syllable_span, tuple) and len(syllable_span) == 2:
+            pattern.syllable_span = syllable_span
+
+        stress_alignment = payload.get("stress_alignment")
+        if isinstance(stress_alignment, (int, float)):
+            pattern.stress_alignment = float(stress_alignment)
+
+        pattern.prosody_profile = dict(payload.get("prosody_profile", {}))
+
+    def _normalize_seed_candidates(self, module1_seeds: Optional[List[Any]]) -> List[SeedCandidate]:
+        return self._cached_normalize_seeds(module1_seeds)
 
     def _normalize_module1_candidates(self, candidates: Optional[List[Any]]) -> List[Dict[str, Any]]:
         return normalize_module1_candidates(candidates, value_sanitizer=self._safe_float)
 
     def _extract_suffixes(self, word: str) -> Set[str]:
-        return extract_suffixes(word)
+        normalized = str(word or "").lower().strip()
+        cached = self._suffix_cache.get(normalized)
+        if cached is not None:
+            return set(cached)
+
+        suffixes = extract_suffixes(word)
+        self._suffix_cache[normalized] = tuple(sorted(suffixes))
+        return set(suffixes)
 
     def _query_seed_neighbors(self, cursor: Any, seed_word: str, limit: int) -> List[Dict[str, Any]]:
-        return self.repository.fetch_seed_neighbors(seed_word, limit)
+        key = (str(seed_word or "").lower().strip(), int(limit))
+        cached = self._seed_neighbor_cache.get(key)
+        if cached is not None:
+            return [row.copy() for row in cached]
+
+        rows = self.repository.fetch_seed_neighbors(seed_word, limit)
+        cached_rows = tuple(dict(row) for row in rows)
+        self._seed_neighbor_cache[key] = cached_rows
+        return [row.copy() for row in cached_rows]
 
     def _query_suffix_matches(self, cursor: Any, suffix: str, limit: int) -> List[Dict[str, Any]]:
-        return self.repository.fetch_suffix_matches(suffix, limit)
+        key = (str(suffix or "").lower().strip(), int(limit))
+        cached = self._suffix_match_cache.get(key)
+        if cached is not None:
+            return [row.copy() for row in cached]
+
+        rows = self.repository.fetch_suffix_matches(suffix, limit)
+        cached_rows = tuple(dict(row) for row in rows)
+        self._suffix_match_cache[key] = cached_rows
+        return [row.copy() for row in cached_rows]
 
     def _attach_profile(self, pattern: AntiLLMPattern) -> None:
+        source_key = pattern.source_word.lower().strip()
+        target_key = pattern.target_word.lower().strip()
+        if not source_key or not target_key:
+            return
+
+        cache_key = (source_key, target_key)
+        cached = self._profile_cache.get(cache_key)
+        if cached is _PROFILE_CACHE_MISS:
+            return
+        if isinstance(cached, dict):
+            self._apply_profile_data(pattern, cached)
+            return
+
         analyzer = getattr(self, "phonetic_analyzer", None)
         if analyzer is None:
             return
@@ -155,43 +448,22 @@ class AntiLLMRhymeEngine:
 
         profile_dict = normalize_profile_dict(profile)
         if not profile_dict:
+            self._profile_cache[cache_key] = _PROFILE_CACHE_MISS
             return
 
-        pattern.feature_profile = profile_dict
-
-        bradley = profile_dict.get("bradley_device")
-        if isinstance(bradley, str) and bradley:
-            pattern.bradley_device = bradley
-
-        syllable_span = profile_dict.get("syllable_span")
-        if isinstance(syllable_span, (list, tuple)) and len(syllable_span) == 2:
-            try:
-                pattern.syllable_span = (
-                    int(syllable_span[0]),
-                    int(syllable_span[1]),
-                )
-            except (TypeError, ValueError):
-                pass
-
-        stress_alignment = profile_dict.get("stress_alignment")
-        if isinstance(stress_alignment, (int, float)):
-            pattern.stress_alignment = float(stress_alignment)
-
-        internal_score = profile_dict.get("internal_rhyme_score")
-        if isinstance(internal_score, (int, float)):
-            pattern.rarity_score *= 1.0 + max(0.0, float(internal_score)) * 0.15
-
-        pattern.prosody_profile = {
-            "complexity_tag": "dense"
-            if pattern.syllable_span and max(pattern.syllable_span) >= 3
-            else "steady",
-            "stress_alignment": pattern.stress_alignment,
-            "assonance": profile_dict.get("assonance_score"),
-            "consonance": profile_dict.get("consonance_score"),
-        }
+        payload = self._build_profile_payload(profile_dict)
+        self._profile_cache[cache_key] = payload
+        self._apply_profile_data(pattern, payload)
 
     def _get_phonetic_fingerprint(self, word: str) -> Set[str]:
-        return phonetic_fingerprint(word)
+        normalized = str(word or "").lower().strip()
+        cached = self._fingerprint_cache.get(normalized)
+        if cached is not None:
+            return set(cached)
+
+        fingerprint = phonetic_fingerprint(word)
+        self._fingerprint_cache[normalized] = tuple(sorted(fingerprint))
+        return set(fingerprint)
 
     def _ensure_seed_resources(self) -> None:
         if self._seed_resources_initialized:
@@ -226,26 +498,31 @@ class AntiLLMRhymeEngine:
             return []
 
         source_word = source_word.lower().strip()
-        patterns: List[AntiLLMPattern] = []
+        self._prepare_source_context(source_word)
 
-        signature_hints: Set[str] = set()
-        if seed_signatures:
-            signature_hints.update({str(sig).strip() for sig in seed_signatures if sig})
+        cached_patterns = self._pattern_cache.get(source_word, [])
+        patterns: List[AntiLLMPattern] = list(cached_patterns)
 
-        normalized_seeds = normalize_seed_candidates(
+        seed_signature_set = set(seed_signatures) if seed_signatures else None
+        delivered_word_set = set(delivered_words) if delivered_words else None
+
+        normalized_seeds, signature_hints, delivered_set = self._prepare_seed_context(
+            source_word,
             module1_seeds,
-            self._get_word_rarity,
-            value_sanitizer=self._safe_float,
+            seed_signature_set,
+            delivered_word_set,
         )
-        for seed in normalized_seeds:
-            signature_hints.update(seed.signatures)
-
-        delivered_set: Set[str] = {source_word}
-        if delivered_words:
-            delivered_set.update({str(word).lower().strip() for word in delivered_words if word})
-        delivered_set.update({seed.normalized() for seed in normalized_seeds})
 
         seen_targets: Set[str] = set(delivered_set)
+        for pattern in patterns:
+            normalized_target = pattern.target_word.lower().strip()
+            if normalized_target:
+                seen_targets.add(normalized_target)
+
+        if len(patterns) >= limit:
+            return patterns[:limit]
+
+        new_patterns_added = False
 
         if normalized_seeds:
             seed_patterns = self._expand_from_seed_candidates(
@@ -264,11 +541,50 @@ class AntiLLMRhymeEngine:
                     continue
                 patterns.append(pattern)
                 seen_targets.add(normalized_target)
+                new_patterns_added = True
 
         if len(patterns) >= limit:
+            cache_cap = max(limit, 64)
+            self._pattern_cache[source_word] = patterns[:cache_cap]
             return patterns[:limit]
 
         per_strategy = max(1, limit // 4)
+
+        rare_rows = self._fetch_strategy_rows(
+            "rare",
+            source_word,
+            per_strategy * 2,
+            self.repository.fetch_rare_combinations,
+        )
+        rarity_lookup = self._prefetch_rarities(row.get("target_word") for row in rare_rows)
+        rare_cultural_lookup = self._prefetch_cultural_multipliers(
+            row.get("cultural_significance") for row in rare_rows
+        )
+
+        phonological_rows = self._fetch_strategy_rows(
+            "phonological",
+            source_word,
+            per_strategy * 2,
+            self.repository.fetch_phonological_challenges,
+        )
+
+        cultural_rows = self._fetch_strategy_rows(
+            "cultural",
+            source_word,
+            per_strategy * 2,
+            self.repository.fetch_cultural_depth_patterns,
+        )
+
+        cultural_lookup = self._prefetch_cultural_multipliers(
+            row.get("cultural_significance") for row in cultural_rows
+        )
+
+        syllable_rows = self._fetch_strategy_rows(
+            "syllable",
+            source_word,
+            per_strategy * 2,
+            self.repository.fetch_complex_syllable_patterns,
+        )
 
         strategy_batches = [
             find_rare_combinations(
@@ -279,6 +595,9 @@ class AntiLLMRhymeEngine:
                 self.cultural_depth_weights,
                 self._attach_profile,
                 self.anti_llm_stats,
+                rows=rare_rows,
+                rarity_lookup=rarity_lookup,
+                cultural_multiplier_lookup=rare_cultural_lookup,
             ),
             find_phonological_challenges(
                 self.repository,
@@ -287,6 +606,7 @@ class AntiLLMRhymeEngine:
                 self._analyze_phonological_complexity,
                 self._attach_profile,
                 self.anti_llm_stats,
+                rows=phonological_rows,
             ),
             find_cultural_depth_patterns(
                 self.repository,
@@ -295,6 +615,8 @@ class AntiLLMRhymeEngine:
                 self.cultural_depth_weights,
                 self._attach_profile,
                 self.anti_llm_stats,
+                rows=cultural_rows,
+                cultural_multiplier_lookup=cultural_lookup,
             ),
             find_complex_syllable_patterns(
                 self.repository,
@@ -302,6 +624,7 @@ class AntiLLMRhymeEngine:
                 per_strategy * 2,
                 self._calculate_syllable_complexity,
                 self._attach_profile,
+                rows=syllable_rows,
             ),
         ]
 
@@ -314,10 +637,15 @@ class AntiLLMRhymeEngine:
                     continue
                 patterns.append(pattern)
                 seen_targets.add(normalized_target)
+                new_patterns_added = True
             if len(patterns) >= limit:
                 break
 
-        patterns.sort(key=lambda item: item.rarity_score * item.confidence, reverse=True)
+        if new_patterns_added or len(patterns) != len(cached_patterns):
+            patterns.sort(key=lambda item: item.rarity_score * item.confidence, reverse=True)
+
+        cache_cap = max(limit, 64)
+        self._pattern_cache[source_word] = patterns[:cache_cap]
         return patterns[:limit]
 
     # ------------------------------------------------------------------
@@ -363,33 +691,46 @@ class AntiLLMRhymeEngine:
         )
 
     def _analyze_phonological_complexity(self, word1: str, word2: str) -> float:
+        key = (str(word1 or "").lower().strip(), str(word2 or "").lower().strip())
+        cached = self._phonological_complexity_cache.get(key)
+        if cached is not None:
+            return cached
+
         complexity = 0.0
-        vowels1 = re.findall(r"[aeiou]+", word1)
-        vowels2 = re.findall(r"[aeiou]+", word2)
+        vowels1 = re.findall(r"[aeiou]+", key[0])
+        vowels2 = re.findall(r"[aeiou]+", key[1])
         if vowels1 and vowels2 and vowels1[-1] != vowels2[-1]:
             complexity += 1.0
-        consonants1 = re.sub(r"[aeiou]", "", word1)
-        consonants2 = re.sub(r"[aeiou]", "", word2)
+        consonants1 = re.sub(r"[aeiou]", "", key[0])
+        consonants2 = re.sub(r"[aeiou]", "", key[1])
         if len(consonants1) >= 3 or len(consonants2) >= 3:
             complexity += 1.5
-        if (word1.endswith("e") and not word2.endswith("e")) or (
-            word2.endswith("e") and not word1.endswith("e")
+        if (key[0].endswith("e") and not key[1].endswith("e")) or (
+            key[1].endswith("e") and not key[0].endswith("e")
         ):
             complexity += 1.0
+        self._phonological_complexity_cache[key] = complexity
         return complexity
 
     def _calculate_syllable_complexity(self, word: str) -> float:
-        syllable_count = estimate_syllable_count(word)
+        original = str(word or "").strip()
+        normalized = original.lower()
+        cached = self._syllable_complexity_cache.get(normalized)
+        if cached is not None:
+            return cached
+
+        syllable_count = estimate_syllable_count(original)
         complexity = syllable_count * 0.5
-        if len(word) >= 8 and "-" not in word:
+        if len(normalized) >= 8 and "-" not in normalized:
             complexity += 1.0
         pattern_changes = 0
-        for i in range(1, len(word)):
-            is_vowel_now = word[i] in "aeiou"
-            was_vowel_before = word[i - 1] in "aeiou"
+        for i in range(1, len(normalized)):
+            is_vowel_now = normalized[i] in "aeiou"
+            was_vowel_before = normalized[i - 1] in "aeiou"
             if is_vowel_now != was_vowel_before:
                 pattern_changes += 1
         complexity += pattern_changes * 0.1
+        self._syllable_complexity_cache[normalized] = complexity
         return complexity
 
     def get_anti_llm_effectiveness_score(self, pattern: AntiLLMPattern) -> float:

--- a/anti_llm/strategies.py
+++ b/anti_llm/strategies.py
@@ -66,18 +66,31 @@ def find_rare_combinations(
     cultural_weights: Mapping[str, float],
     attach_profile: Callable[[AntiLLMPattern], None],
     stats: Optional[Dict[str, int]] = None,
+    rows: Optional[List[Dict[str, object]]] = None,
+    rarity_lookup: Optional[Mapping[str, float]] = None,
+    cultural_multiplier_lookup: Optional[Mapping[str, float]] = None,
 ) -> List[AntiLLMPattern]:
-    rows = repository.fetch_rare_combinations(source_word, limit * 3)
+    query_rows = rows if rows is not None else repository.fetch_rare_combinations(
+        source_word, limit * 3
+    )
     patterns: List[AntiLLMPattern] = []
 
-    for row in rows:
+    for row in query_rows:
         target = str(row.get("target_word") or "").strip()
         if not target:
             continue
 
-        rarity_score = get_rarity(target)
+        normalized_target = target.lower()
+        if rarity_lookup is not None and normalized_target in rarity_lookup:
+            rarity_score = rarity_lookup[normalized_target]
+        else:
+            rarity_score = get_rarity(normalized_target)
+
         cultural_sig = str(row.get("cultural_significance") or "")
-        cultural_multiplier = cultural_weights.get(cultural_sig, 1.0)
+        if cultural_multiplier_lookup is not None and cultural_sig in cultural_multiplier_lookup:
+            cultural_multiplier = cultural_multiplier_lookup[cultural_sig]
+        else:
+            cultural_multiplier = cultural_weights.get(cultural_sig, 1.0)
         final_rarity = rarity_score * cultural_multiplier
 
         if final_rarity < 2.0:
@@ -110,11 +123,14 @@ def find_phonological_challenges(
     analyze_complexity: Callable[[str, str], float],
     attach_profile: Callable[[AntiLLMPattern], None],
     stats: Optional[Dict[str, int]] = None,
+    rows: Optional[List[Dict[str, object]]] = None,
 ) -> List[AntiLLMPattern]:
-    rows = repository.fetch_phonological_challenges(source_word, limit * 2)
+    query_rows = rows if rows is not None else repository.fetch_phonological_challenges(
+        source_word, limit * 2
+    )
     patterns: List[AntiLLMPattern] = []
 
-    for row in rows:
+    for row in query_rows:
         target = str(row.get("target_word") or "").strip()
         if not target:
             continue
@@ -150,17 +166,24 @@ def find_cultural_depth_patterns(
     cultural_weights: Mapping[str, float],
     attach_profile: Callable[[AntiLLMPattern], None],
     stats: Optional[Dict[str, int]] = None,
+    rows: Optional[List[Dict[str, object]]] = None,
+    cultural_multiplier_lookup: Optional[Mapping[str, float]] = None,
 ) -> List[AntiLLMPattern]:
-    rows = repository.fetch_cultural_depth_patterns(source_word, limit * 2)
+    query_rows = rows if rows is not None else repository.fetch_cultural_depth_patterns(
+        source_word, limit * 2
+    )
     patterns: List[AntiLLMPattern] = []
 
-    for row in rows:
+    for row in query_rows:
         target = str(row.get("target_word") or "").strip()
         if not target:
             continue
 
         cultural_sig = str(row.get("cultural_significance") or "")
-        cultural_weight = cultural_weights.get(cultural_sig, 1.0)
+        if cultural_multiplier_lookup is not None and cultural_sig in cultural_multiplier_lookup:
+            cultural_weight = cultural_multiplier_lookup[cultural_sig]
+        else:
+            cultural_weight = cultural_weights.get(cultural_sig, 1.0)
 
         pattern = AntiLLMPattern(
             source_word=source_word,
@@ -188,11 +211,14 @@ def find_complex_syllable_patterns(
     limit: int,
     calculate_syllable_complexity: Callable[[str], float],
     attach_profile: Callable[[AntiLLMPattern], None],
+    rows: Optional[List[Dict[str, object]]] = None,
 ) -> List[AntiLLMPattern]:
-    rows = repository.fetch_complex_syllable_patterns(source_word, limit * 2)
+    query_rows = rows if rows is not None else repository.fetch_complex_syllable_patterns(
+        source_word, limit * 2
+    )
     patterns: List[AntiLLMPattern] = []
 
-    for row in rows:
+    for row in query_rows:
         target = str(row.get("target_word") or "").strip()
         if not target:
             continue


### PR DESCRIPTION
## Summary
- add reusable caches to the anti-LLM engine for normalized seeds, rarity lookups, phonetic fingerprints, repository rows, and profile data
- teach SeedCandidate and seed expansion helpers to store derived fingerprints, suffixes, and signature hints so seed expansions reuse work
- allow strategy helpers to accept prefetched rows and cached rarity/multiplier lookups to avoid redundant database hits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c2d048f88322ab3207a8bf211a4e