### PR TITLE
Improve database normalization and indexing

### DIFF
--- a/rhyme_rarity/core/rarity_map.py
+++ b/rhyme_rarity/core/rarity_map.py
@@ -86,14 +86,24 @@ class WordRarityMap:
         try:
             with sqlite3.connect(str(canonical)) as conn:
                 cursor = conn.cursor()
-                cursor.execute(
-                    """
-                    SELECT LOWER(target_word), COUNT(*)
-                    FROM song_rhyme_patterns
-                    WHERE target_word IS NOT NULL AND TRIM(target_word) != ''
-                    GROUP BY LOWER(target_word)
-                    """
-                )
+                try:
+                    cursor.execute(
+                        """
+                        SELECT target_word_normalized, COUNT(*)
+                        FROM song_rhyme_patterns
+                        WHERE target_word_normalized IS NOT NULL
+                        GROUP BY target_word_normalized
+                        """
+                    )
+                except sqlite3.OperationalError:
+                    cursor.execute(
+                        """
+                        SELECT LOWER(target_word), COUNT(*)
+                        FROM song_rhyme_patterns
+                        WHERE target_word IS NOT NULL AND TRIM(target_word) != ''
+                        GROUP BY LOWER(target_word)
+                        """
+                    )
                 rows = cursor.fetchall()
         except sqlite3.Error:
             return False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,6 +36,7 @@ if str(PROJECT_ROOT) not in sys.path:
 import rhyme_rarity.app.services.search_service as search_service_module
 from rhyme_rarity.app.app import RhymeRarityApp
 from anti_llm import AntiLLMPattern
+from rhyme_rarity.app.data.database import SQLiteRhymeRepository
 from rhyme_rarity.core.cmudict_loader import VOWEL_PHONEMES
 
 
@@ -47,28 +48,11 @@ if os.path.isdir("__pycache__"):
 
 
 def create_test_database(db_path):
+    repository = SQLiteRhymeRepository(db_path)
+    repository.ensure_database()
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        CREATE TABLE song_rhyme_patterns (
-            id INTEGER PRIMARY KEY,
-            pattern TEXT,
-            source_word TEXT,
-            target_word TEXT,
-            artist TEXT,
-            song_title TEXT,
-            genre TEXT,
-            line_distance INTEGER,
-            confidence_score REAL,
-            phonetic_similarity REAL,
-            cultural_significance TEXT,
-            source_context TEXT,
-            target_context TEXT
-        )
-        """
-    )
-
+    cursor.execute("DELETE FROM song_rhyme_patterns")
     rows = [
         (
             1,
@@ -170,6 +154,8 @@ def create_test_database(db_path):
     )
     conn.commit()
     conn.close()
+
+    repository.refresh_normalized_columns()
 
 
 def test_search_rhymes_returns_counterpart_for_target_word(tmp_path):


### PR DESCRIPTION
## Summary
- add normalized word and artist columns, refresh helpers, and covering indexes so rhyme queries can rely on case-insensitive lookups without expression scans
- update SQLitePatternRepository and cultural engine queries to use normalized predicates, trim projections, and remove expensive random ordering
- align supporting utilities and tests with the normalized schema, including WordRarityMap fallbacks and test database setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c5ee2f6083228528a5ae8c3397ad