### PR TITLE
Rename helpers for clearer intent

### DIFF
--- a/anti_llm/seed_expansion.py
+++ b/anti_llm/seed_expansion.py
@@ -114,10 +114,11 @@ def normalize_seed_candidates(
     return normalized[:8]
 
 
-def normalize_module1_candidates(
+def normalize_seed_candidate_payloads(
     candidates: Optional[List[Any]],
     value_sanitizer: Callable[[Any, float], float] = safe_float,
 ) -> List[Dict[str, Any]]:
+    """Normalise raw seed candidate payloads into a consistent structure of word, similarity, combined, and rarity scores."""
     normalized: List[Dict[str, Any]] = []
     if not candidates:
         return normalized
@@ -287,7 +288,10 @@ def expand_from_seed_candidates(
                 raw_candidates = []
 
             candidate_dicts.extend(
-                (module1_normalizer or (lambda candidates: normalize_module1_candidates(candidates, value_sanitizer)))(
+                (
+                    module1_normalizer
+                    or (lambda candidates: normalize_seed_candidate_payloads(candidates, value_sanitizer))
+                )(
                     raw_candidates
                 )
             )
@@ -394,7 +398,7 @@ def expand_from_seed_candidates(
 __all__ = [
     "safe_float",
     "normalize_seed_candidates",
-    "normalize_module1_candidates",
+    "normalize_seed_candidate_payloads",
     "extract_suffixes",
     "phonetic_fingerprint",
     "expand_from_seed_candidates",

--- a/rhyme_rarity/app/ui/gradio.py
+++ b/rhyme_rarity/app/ui/gradio.py
@@ -51,14 +51,14 @@ def create_interface(
     cultural_engine = getattr(search_service, "cultural_engine", None)
     if cultural_engine:
         for raw_label in getattr(cultural_engine, "cultural_categories", {}).keys():
-            normalized = search_service.normalize_source_name(raw_label)
+            normalized = search_service.normalize_filter_label(raw_label)
             if normalized:
                 normalized_cultural_labels.add(normalized)
 
     genre_options: List[str] = []
     try:
         for value in repository.get_cultural_significance_labels():
-            normalized = search_service.normalize_source_name(value)
+            normalized = search_service.normalize_filter_label(value)
             if normalized:
                 normalized_cultural_labels.add(normalized)
         genre_options = repository.get_genres()

--- a/tests/test_anti_llm_engine.py
+++ b/tests/test_anti_llm_engine.py
@@ -60,7 +60,7 @@ def test_seed_expansion_uses_shared_rarity_map():
     ]
     engine._extract_suffixes = lambda word: set()  # type: ignore[assignment]
     engine._query_suffix_matches = lambda cursor, suffix, limit: []  # type: ignore[assignment]
-    engine._normalize_module1_candidates = lambda candidates: []  # type: ignore[assignment]
+    engine._normalize_seed_candidate_payloads = lambda candidates: []  # type: ignore[assignment]
     engine._get_phonetic_fingerprint = lambda word: set()  # type: ignore[assignment]
     engine._analyze_phonological_complexity = lambda w1, w2: 0.0  # type: ignore[assignment]
     engine._calculate_syllable_complexity = lambda word: 0.0  # type: ignore[assignment]

--- a/tests/test_search_service_input_validation.py
+++ b/tests/test_search_service_input_validation.py
@@ -127,8 +127,8 @@ def test_search_rhymes_zero_limit_short_circuits_results() -> None:
     assert result == {"cmu": [], "anti_llm": [], "rap_db": []}
 
 
-def test_normalize_source_name_sanitises_whitespace_and_underscores() -> None:
+def test_normalize_filter_label_sanitises_whitespace_and_underscores() -> None:
     service = make_service([])
 
-    assert service.normalize_source_name(None) == ""
-    assert service.normalize_source_name("  Mixed_CASE_Name  ") == "mixed-case-name"
+    assert service.normalize_filter_label(None) == ""
+    assert service.normalize_filter_label("  Mixed_CASE_Name  ") == "mixed-case-name"


### PR DESCRIPTION
## Summary
- rename SearchService helpers to clarify spelling-signature cache usage and score normalization semantics
- rename filter label normalizer and update UI/tests to reference the clearer API
- rename anti-LLM seed normalization helpers and CMU fetch method with expanded docstrings for better intent disclosure

## Testing
- pytest tests/test_search_service_input_validation.py tests/test_anti_llm_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c5946b98832296c8b826792a7901