### PR TITLE
Refactor search orchestration and CMU repository integration

### DIFF
--- a/rhyme_rarity/core/__init__.py
+++ b/rhyme_rarity/core/__init__.py
@@ -6,6 +6,7 @@ from .analyzer import (
     RARITY_SIMILARITY_WEIGHT,
     get_cmu_rhymes,
 )
+from .cmu_repository import CmuRhymeRepository, DefaultCmuRhymeRepository
 from .cmudict_loader import CMUDictLoader, DEFAULT_CMU_LOADER
 from .feature_profile import (
     PhoneticMatch,
@@ -26,6 +27,8 @@ __all__ = [
     "PhoneticMatch",
     "extract_phrase_components",
     "get_cmu_rhymes",
+    "CmuRhymeRepository",
+    "DefaultCmuRhymeRepository",
     "RARITY_SIMILARITY_WEIGHT",
     "RARITY_NOVELTY_WEIGHT",
 ]

--- a/rhyme_rarity/core/cmu_repository.py
+++ b/rhyme_rarity/core/cmu_repository.py
@@ -1,0 +1,44 @@
+"""Repository abstraction for CMU-derived rhyme lookups."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Protocol
+
+from .analyzer import EnhancedPhoneticAnalyzer, get_cmu_rhymes
+
+
+class CmuRhymeRepository(Protocol):
+    """Protocol describing the minimal CMU lookup interface used by services."""
+
+    def lookup(
+        self,
+        source_word: str,
+        limit: int,
+        *,
+        analyzer: Optional[EnhancedPhoneticAnalyzer] = None,
+        cmu_loader: Optional[Any] = None,
+    ) -> List[Any]:
+        """Return CMU candidates for ``source_word`` with the given ``limit``."""
+
+
+class DefaultCmuRhymeRepository:
+    """Repository implementation backed by :func:`get_cmu_rhymes`."""
+
+    def lookup(
+        self,
+        source_word: str,
+        limit: int,
+        *,
+        analyzer: Optional[EnhancedPhoneticAnalyzer] = None,
+        cmu_loader: Optional[Any] = None,
+    ) -> List[Any]:
+        return get_cmu_rhymes(
+            source_word,
+            limit=limit,
+            analyzer=analyzer,
+            cmu_loader=cmu_loader,
+        )
+
+
+__all__ = ["CmuRhymeRepository", "DefaultCmuRhymeRepository"]
+

--- a/tests/test_search_service_filters.py
+++ b/tests/test_search_service_filters.py
@@ -49,6 +49,20 @@ class DummyRepository:
         return ([], [])
 
 
+class DummyCmuRepository:
+    """Repository stub returning no CMU results."""
+
+    def lookup(
+        self,
+        source_word: str,
+        limit: int,
+        *,
+        analyzer: Any | None = None,
+        cmu_loader: Any | None = None,
+    ) -> list[Any]:
+        return []
+
+
 class DummyAntiEngine:
     """Anti-LLM engine stub returning predetermined patterns."""
 
@@ -78,13 +92,13 @@ def _patch_search_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     monkeypatch.setattr(search_service_module, "extract_phrase_components", fake_extract_components)
-    monkeypatch.setattr(search_service_module, "get_cmu_rhymes", lambda *args, **kwargs: [])
 
 
 def make_service(patterns: Iterable[DummyPattern]) -> SearchService:
     repo = DummyRepository()
     anti_engine = DummyAntiEngine(patterns)
-    return SearchService(repository=repo, anti_llm_engine=anti_engine)
+    cmu_repo = DummyCmuRepository()
+    return SearchService(repository=repo, anti_llm_engine=anti_engine, cmu_repository=cmu_repo)
 
 
 def _targets(result: dict[str, list[dict]]) -> list[str]:

--- a/tests/test_search_service_input_validation.py
+++ b/tests/test_search_service_input_validation.py
@@ -46,6 +46,20 @@ class DummyRepository:
         return ([], [])
 
 
+class DummyCmuRepository:
+    """Repository stub returning no CMU results."""
+
+    def lookup(
+        self,
+        source_word: str,
+        limit: int,
+        *,
+        analyzer: Any | None = None,
+        cmu_loader: Any | None = None,
+    ) -> list[Any]:
+        return []
+
+
 class DummyAntiEngine:
     """Anti-LLM engine stub returning predetermined patterns."""
 
@@ -75,13 +89,13 @@ def _patch_search_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     monkeypatch.setattr(search_service_module, "extract_phrase_components", fake_extract_components)
-    monkeypatch.setattr(search_service_module, "get_cmu_rhymes", lambda *args, **kwargs: [])
 
 
 def make_service(patterns: Iterable[DummyPattern]) -> SearchService:
     repo = DummyRepository()
     anti_engine = DummyAntiEngine(patterns)
-    return SearchService(repository=repo, anti_llm_engine=anti_engine)
+    cmu_repo = DummyCmuRepository()
+    return SearchService(repository=repo, anti_llm_engine=anti_engine, cmu_repository=cmu_repo)
 
 
 def _anti_targets(result: dict[str, list[dict]]) -> list[str]:


### PR DESCRIPTION
## Summary
- extract a `RhymeQueryOrchestrator` and `RhymeResultFormatter`, leaving `SearchService` as a thin facade
- add a CMU rhyme repository abstraction and connect it to the anti-LLM engine and application wiring
- update the search service unit tests to stub the new repository-driven interfaces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d417c37df08322967727ecaabcae41