### PR TITLE
Preserve rhythm metadata through cultural filtering

### DIFF
--- a/cultural/engine.py
+++ b/cultural/engine.py
@@ -399,41 +399,47 @@ class CulturalIntelligenceEngine:
             'regional_mappings': len(self.regional_mappings)
         }
 
-# Example usage and testing
-if __name__ == "__main__":
+def run_demo() -> Dict[str, Any]:
+    """Execute a demo run with structured logging for observability."""
+
     engine = CulturalIntelligenceEngine()
-    
-    # Test cultural context generation
+    logger = get_logger(__name__).bind(component="cultural_demo")
+    logger.info("Starting Cultural Intelligence Engine demo")
+
     test_pattern = {
         'artist': 'eminem',
         'song': 'Lose Yourself',
         'source_word': 'mind',
-        'target_word': 'find'
+        'target_word': 'find',
     }
-    
-    print("🎯 Testing Cultural Intelligence Engine:")
-    print("=" * 50)
-    
+
     context = engine.get_cultural_context(test_pattern)
-    print(f"Cultural Context for Eminem:")
-    print(f"  • Era: {context.era}")
-    print(f"  • Cultural Impact: {context.cultural_significance}")
-    print(f"  • Regional Origin: {context.regional_origin}")
-    print(f"  • Style Characteristics: {context.style_characteristics}")
-    
     rarity_score = engine.get_cultural_rarity_score(context)
-    print(f"  • Cultural Rarity Score: {rarity_score:.2f}")
-    
-    # Test cultural pattern finding
+    logger.info(
+        "Demo cultural context generated",
+        context={
+            'artist': context.artist,
+            'era': context.era,
+            'rarity_score': rarity_score,
+        },
+    )
+
     cultural_patterns = engine.find_cultural_patterns("love", limit=3)
-    print(f"\nCultural patterns for 'love':")
-    for pattern in cultural_patterns:
-        print(f"  • '{pattern['target_word']}' - {pattern['artist']} (rarity: {pattern['cultural_rarity']:.2f})")
-    
-    # Performance stats
-    print(f"\n📊 Performance Stats:")
+    logger.info(
+        "Demo cultural patterns retrieved",
+        context={'pattern_count': len(cultural_patterns)},
+    )
+
     stats = engine.get_performance_stats()
-    for key, value in stats.items():
-        print(f"  • {key}: {value}")
-    
-    print("\n✅ Module 3 Enhanced Cultural Database ready for integration")
+    logger.info("Cultural engine performance snapshot", context=stats)
+
+    return {
+        'context': context,
+        'rarity_score': rarity_score,
+        'patterns': cultural_patterns,
+        'stats': stats,
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo entry
+    run_demo()

--- a/rhyme_rarity/core/analyzer.py
+++ b/rhyme_rarity/core/analyzer.py
@@ -1033,24 +1033,37 @@ def get_cmu_rhymes(
     scored_candidates.sort(key=lambda item: item.get("combined", 0.0), reverse=True)
     return scored_candidates[:limit]
 
-# Example usage and testing
-if __name__ == "__main__":
+def run_demo() -> List[Dict[str, Any]]:
+    """Execute a structured logging demo of the phonetic analyzer."""
+
     analyzer = EnhancedPhoneticAnalyzer()
-    
-    # Test some rhyme pairs
-    test_pairs = [
+    logger = get_logger(__name__).bind(component="phonetic_demo")
+    logger.info("Starting Enhanced Phonetic Analyzer demo")
+
+    demo_pairs = [
         ("love", "above"),
         ("mind", "find"),
         ("flow", "go"),
         ("money", "honey"),
-        ("time", "rhyme")
+        ("time", "rhyme"),
     ]
-    
-    print("🎵 Testing Enhanced Phonetic Analyzer:")
-    print("=" * 50)
-    
-    for word1, word2 in test_pairs:
-        match = analyzer.analyze_rhyme_pattern(word1, word2)
-        print(f"'{word1}' / '{word2}': {match.similarity_score:.3f} ({match.rhyme_type})")
-        
-    print("\n✅ Module 1 Enhanced Core Phonetic ready for integration")
+
+    results: List[Dict[str, Any]] = []
+    for source, target in demo_pairs:
+        match = analyzer.analyze_rhyme_pattern(source, target)
+        payload = {
+            "source": source,
+            "target": target,
+            "similarity": match.similarity_score,
+            "rhyme_type": match.rhyme_type,
+            "syllable_span": match.syllable_span,
+        }
+        results.append(payload)
+        logger.info("Demo rhyme analysed", context=payload)
+
+    logger.info("Enhanced phonetic analyzer demo completed", context={"pair_count": len(results)})
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo entry
+    run_demo()


### PR DESCRIPTION
## Summary
- add helper that normalises stress alignment metadata and invoke it when collecting phonetic, cultural, and anti-LLM matches so rhythm scores survive filtering
- extend the result formatter to surface cadence and rhythm information while keeping cultural context bullets concise
- move the phonetic and cultural demo scripts behind `run_demo()` helpers that emit structured logging instead of print statements

## Testing
- pytest tests/test_app.py::test_search_rhymes_respects_rhyme_type_and_rhythm_filters
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4752ea7c88322bf7c1b70766db008