### PR TITLE
Remove gated metadata fields from rhyme formatting

### DIFF
--- a/rhyme_rarity/app/services/search_service.py
+++ b/rhyme_rarity/app/services/search_service.py
@@ -2175,18 +2175,6 @@ class RhymeResultFormatter:
                 )
                 details.append(f"• Context signatures: {context_text}")
 
-            gate_mode = entry.get("threshold_gate")
-            if gate_mode:
-                details.append(
-                    f"• Threshold gate: {str(gate_mode).replace('_', ' ').title()}"
-                )
-                gate_threshold = entry.get("phonetic_threshold")
-                if gate_threshold is not None:
-                    try:
-                        details.append(f"• Gate threshold: {float(gate_threshold):.2f}")
-                    except (TypeError, ValueError):
-                        pass
-
             return details
 
         source_profile = rhymes.get("source_profile") or {}
@@ -2252,14 +2240,6 @@ class RhymeResultFormatter:
 
         def _collect_details(entry: Dict[str, Any], key: str) -> List[str]:
             details = list(_format_entry(entry))
-            weakness = entry.get("llm_weakness_type")
-            if weakness:
-                details.append(
-                    f"• LLM weakness: {str(weakness).replace('_', ' ').title()}"
-                )
-            depth = entry.get("cultural_depth")
-            if depth:
-                details.append(f"• Cultural depth: {depth}")
             if key == "rap_db":
                 artist = entry.get("artist")
                 song = entry.get("song")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -613,8 +613,8 @@ def test_anti_llm_patterns_in_formatting(tmp_path):
 
     assert "SHOVE" in formatted
     assert "Rarity: 4.20" in formatted
-    assert "• LLM weakness: Rare Word Combinations" in formatted
-    assert "• Cultural depth: Sentinel Depth" in formatted
+    assert "• LLM weakness:" not in formatted
+    assert "• Cultural depth:" not in formatted
 
 
 def test_min_confidence_filters_phonetic_candidates(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- stop including threshold gate and gate threshold diagnostics when formatting rhyme entries
- remove LLM weakness and cultural depth metadata from formatted anti-LLM results
- update anti-LLM formatting test expectations to ensure the removed metadata stays hidden

## Testing
- `pytest tests/test_app.py -k anti_llm`


------
https://chatgpt.com/codex/tasks/task_e_68d59f3c58048322803cb89a1979a9bd