### PR TITLE
Clarify CMU and anti-LLM relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ RhymeRarity is an experimental research project that explores uncommon rhyme pat
 - **Module 2 – Enhanced Anti-LLM Rhyme Engine** (`module2_enhanced_anti_llm.py`): expands on Module 1 results to prioritise patterns that challenge common LLM failure modes while capturing prosody and internal rhyme complexity.
 - **Module 3 – Enhanced Cultural Database Engine** (`module3_enhanced_cultural_database.py`): layers cultural context, attribution, rhythm-aware metadata, and genre-aware filtering over the rhyme search.
 
+Even though the Gradio demo displays separate "CMU" and "Anti-LLM" columns, both are produced by the phonetic pipeline rooted in Module 1. Module 2 simply extends the CMU seed set with rarity heuristics and prosody-aware synthesis so the combined CMU/Anti-LLM branch represents a single family of outputs. The cultural column is the only branch backed by an independent repository.
+
 The project ships with a Gradio interface (`app.py`) that ties the modules together and exposes an interactive search workflow. When the bundled `patterns.db` file is missing the app automatically creates a demo database populated with sample rhyme patterns so you can explore the workflow immediately.
 
 ### Research-driven rhyme metrics

--- a/docs/search_service_pipeline.md
+++ b/docs/search_service_pipeline.md
@@ -15,6 +15,8 @@ Anti-LLM pattern generation
 Result normalization & return
 ```
 
+> **Note:** The "Anti-LLM" phase does not introduce a distinct dataset. It reuses the CMU-derived phonetic candidates harvested in the previous stage, layering rarity heuristics and synthesis on top of the same pipeline that powers the CMU column in the UI. As a result the product exposes two high-level result families: CMU/Anti-LLM (combined phonetic outputs) and the cultural repository branch.
+
 ## 1. Normalization & Input Preparation
 * Trim, lowercase, and validate the source word while capturing telemetry of raw inputs and limits.
 * Coerce confidence to a float, normalise filter labels (cultural, genre, rhyme type, cadence, Bradley devices), and clamp numeric thresholds for syllables, rarity, stress, and concurrency filters.【F:rhyme_rarity/app/services/search_service.py†L452-L558】


### PR DESCRIPTION
## Summary
- clarify in the README that CMU and anti-LLM outputs share a single phonetic pipeline while cultural results come from a separate repository
- document in the search service pipeline notes that the anti-LLM stage extends CMU candidates rather than relying on its own dataset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b7b1e1308322b363e5deb5446143