### PR TITLE
Handle optional torch dependency in warmup

### DIFF
--- a/rhyme_rarity/app/app.py
+++ b/rhyme_rarity/app/app.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, List, Optional
 
-import torch
+try:
+    import torch
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore[assignment]
 import spaces  # 👈 added
 
 from rhyme_rarity.core import (
@@ -161,6 +164,8 @@ def _should_share_interface() -> bool:
 @spaces.GPU
 def warmup_gpu() -> str:
     """Simple GPU warmup so Hugging Face Spaces detects usage."""
+    if torch is None:
+        return "Torch not installed"
     if torch.cuda.is_available():
         x = torch.rand(1000, 1000, device="cuda")
         _ = torch.matmul(x, x)


### PR DESCRIPTION
## Summary
- wrap the torch import in a try/except so the app loads when PyTorch is unavailable
- short-circuit the GPU warmup helper when torch is missing to avoid runtime errors

## Testing
- python - <<'PY'
from rhyme_rarity.app.app import warmup_gpu, torch
print('torch_present', torch is not None)
print(warmup_gpu())
PY (fails: ModuleNotFoundError: No module named 'spaces')

------
https://chatgpt.com/codex/tasks/task_e_68d69740ebf88322b1e7c8e4404528df