### PR TITLE
Remove invalid pyaudioop dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 # Core interactive application
 gradio>=4.36.1,<5.0
 
-# Audio processing helper required by pydub on Python 3.13+
-pyaudioop>=0.2.0
 
 # Phonetic fallback when the CMU dictionary misses a word
 pronouncing>=0.2.0,<0.3


### PR DESCRIPTION
## Summary
- remove the obsolete pyaudioop dependency from requirements.txt now that no code relies on it
- verify pip install -r requirements.txt succeeds without the unpublished package

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68d6e35facc88322aad6ac656ae53112