### PR TITLE
Split rhyme results into perfect and slant buckets

### DIFF
--- a/rhyme_rarity/app/ui/gradio.py
+++ b/rhyme_rarity/app/ui/gradio.py
@@ -107,7 +107,7 @@ def create_interface(
         with gr.Column(elem_classes=["rr-container"]):
             gr.Markdown(
                 "<h2>🎵 RhymeRarity</h2>\n"
-                "<p>Discover uncommon CMU patterns, LLM-proof multi-word phrases, and rap-inspired cultural rhymes.</p>",
+                "<p>Discover perfect matches, slant surprises, and rap-inspired multi-word rhymes.</p>",
                 elem_classes=["rr-hero"],
             )
             gr.Markdown(
@@ -181,7 +181,7 @@ def create_interface(
                         elem_classes=["rr-button"],
                     )
                     gr.Markdown(
-                        "💡 Enter a word, tune the filters, and click **Find Rhymes** to surface uncommon pairings.",
+                        "💡 Enter a word, tune the filters, and click **Find Rhymes** to surface perfect, slant, and multi-word pairings.",
                         elem_classes=["rr-tip"],
                     )
 

--- a/tests/test_search_service_filters.py
+++ b/tests/test_search_service_filters.py
@@ -139,7 +139,7 @@ def make_service(patterns: Iterable[DummyPattern]) -> SearchService:
 
 def _targets(result: dict[str, list[dict]]) -> list[str]:
     entries: list[dict] = []
-    for bucket in ("uncommon", "multi_word"):
+    for bucket in ("perfect", "slant", "multi_word"):
         entries.extend(result.get(bucket, []))
     return [
         entry["target_word"]
@@ -149,7 +149,7 @@ def _targets(result: dict[str, list[dict]]) -> list[str]:
 
 
 def _first_anti_entry(result: dict[str, list[dict]]) -> dict:
-    for bucket in ("uncommon", "multi_word"):
+    for bucket in ("perfect", "slant", "multi_word"):
         for entry in result.get(bucket, []):
             if entry.get("result_source") == "anti_llm":
                 return entry
@@ -240,7 +240,8 @@ def test_phonetic_only_search_skips_cultural_alignment() -> None:
     result = service.search_rhymes("Echo", result_sources=["phonetic"], limit=5)
 
     assert cultural_engine.align_calls == 0
-    assert any(entry["result_source"] == "phonetic" for entry in result["uncommon"])
+    single_results = list(result.get("perfect", [])) + list(result.get("slant", []))
+    assert any(entry["result_source"] == "phonetic" for entry in single_results)
 
 
 def test_phonetic_with_cultural_results_triggers_alignment() -> None:

--- a/tests/test_search_service_input_validation.py
+++ b/tests/test_search_service_input_validation.py
@@ -100,7 +100,7 @@ def make_service(patterns: Iterable[DummyPattern]) -> SearchService:
 
 def _anti_targets(result: dict[str, list[dict]]) -> list[str]:
     entries: list[dict] = []
-    for bucket in ("uncommon", "multi_word"):
+    for bucket in ("perfect", "slant", "multi_word"):
         entries.extend(result.get(bucket, []))
     return [
         entry["target_word"]
@@ -114,7 +114,7 @@ def test_search_rhymes_returns_empty_for_null_source_word() -> None:
 
     result = service.search_rhymes(None)
 
-    assert result == {"uncommon": [], "multi_word": [], "rap_db": []}
+    assert result == {"perfect": [], "slant": [], "multi_word": [], "rap_db": []}
 
 
 def test_search_rhymes_coerces_invalid_min_confidence() -> None:
@@ -145,7 +145,7 @@ def test_search_rhymes_zero_limit_short_circuits_results() -> None:
 
     result = service.search_rhymes("Echo", limit=0, result_sources=["anti_llm"])
 
-    assert result == {"uncommon": [], "multi_word": [], "rap_db": []}
+    assert result == {"perfect": [], "slant": [], "multi_word": [], "rap_db": []}
 
 
 def test_normalize_filter_label_sanitises_whitespace_and_underscores() -> None:

--- a/tests/test_search_service_telemetry.py
+++ b/tests/test_search_service_telemetry.py
@@ -110,7 +110,7 @@ class DummyCmuRepository:
 
 def _anti_entries(result: dict[str, list[dict]]) -> list[dict]:
     entries: list[dict] = []
-    for bucket in ("uncommon", "multi_word"):
+    for bucket in ("perfect", "slant", "multi_word"):
         entries.extend(result.get(bucket, []))
     return [entry for entry in entries if entry.get("result_source") == "anti_llm"]
 
@@ -154,7 +154,7 @@ def test_search_service_records_branch_timings() -> None:
     )
 
     result = service.search_rhymes("Echo", limit=5, result_sources=["phonetic", "cultural", "anti_llm"])
-    assert result["uncommon"] or result["multi_word"] or result["rap_db"]
+    assert result["perfect"] or result["slant"] or result["multi_word"] or result["rap_db"]
 
     metrics = service.get_latest_telemetry()
     assert metrics["counters"]["search.completed"] == 1
@@ -162,7 +162,7 @@ def test_search_service_records_branch_timings() -> None:
     assert "search.branch.cultural" in metrics["timings"]
     assert "search.branch.anti_llm" in metrics["timings"]
     counts = metrics["metadata"]["result.counts"]
-    assert set(counts.keys()) == {"uncommon", "multi_word", "rap_db"}
+    assert set(counts.keys()) == {"perfect", "slant", "multi_word", "rap_db"}
 
 
 def test_filter_telemetry_tracks_rejections() -> None:
@@ -259,7 +259,7 @@ def test_formatter_emits_cadence_and_stress_diagnostics() -> None:
             },
             "signature_set": ["v:eh|e:cho"],
         },
-        "uncommon": [
+        "perfect": [
             {
                 "target_word": "Echo",
                 "pattern": "echo / echo",
@@ -275,6 +275,7 @@ def test_formatter_emits_cadence_and_stress_diagnostics() -> None:
                 "phonetic_threshold": 0.86,
             }
         ],
+        "slant": [],
         "multi_word": [],
         "rap_db": [],
     }


### PR DESCRIPTION
## Summary
- split the rhyme result aggregation into perfect, slant, and multi-word buckets while keeping the rap database card
- refresh the formatter and Gradio UI copy to surface the new column names
- update service and app tests to exercise the new buckets and expectations

## Testing
- pytest tests/test_search_service_input_validation.py
- pytest tests/test_search_service_filters.py
- pytest tests/test_search_service_telemetry.py
- pytest tests/test_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e275da788322a10730ad5816a910