### PR TITLE
Improve slant rhyme classification

### DIFF
--- a/rhyme_rarity/core/feature_profile.py
+++ b/rhyme_rarity/core/feature_profile.py
@@ -137,10 +137,17 @@ class RhymeFeatureProfile:
     vowel_skeleton_target: str
     consonant_tail_source: str
     consonant_tail_target: str
+    last_vowel_sound_source: str
+    last_vowel_sound_target: str
+    consonant_coda_source: str
+    consonant_coda_target: str
+    consonant_onset_source: str
+    consonant_onset_target: str
     assonance_score: float
     consonance_score: float
     internal_rhyme_score: float
     bradley_device: str
+    rhyme_type: str
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -154,10 +161,17 @@ class RhymeFeatureProfile:
             "vowel_skeleton_target": self.vowel_skeleton_target,
             "consonant_tail_source": self.consonant_tail_source,
             "consonant_tail_target": self.consonant_tail_target,
+            "last_vowel_sound_source": self.last_vowel_sound_source,
+            "last_vowel_sound_target": self.last_vowel_sound_target,
+            "consonant_coda_source": self.consonant_coda_source,
+            "consonant_coda_target": self.consonant_coda_target,
+            "consonant_onset_source": self.consonant_onset_source,
+            "consonant_onset_target": self.consonant_onset_target,
             "assonance_score": self.assonance_score,
             "consonance_score": self.consonance_score,
             "internal_rhyme_score": self.internal_rhyme_score,
             "bradley_device": self.bradley_device,
+            "rhyme_type": self.rhyme_type,
         }
 
 

--- a/tests/test_phonetic_syllables.py
+++ b/tests/test_phonetic_syllables.py
@@ -94,3 +94,29 @@ def test_multi_word_variants_survive_large_single_candidate_lists():
     ]
 
     assert multi_variants, "Expected multi-word variants to survive limit slicing"
+
+
+def test_derive_rhyme_profile_returns_rhyme_type_metadata():
+    analyzer = EnhancedPhoneticAnalyzer()
+
+    profile = analyzer.derive_rhyme_profile("money", "honey")
+
+    assert isinstance(profile, dict)
+    assert profile["rhyme_type"] == "perfect"
+    assert profile["last_vowel_sound_source"] == profile["last_vowel_sound_target"]
+    assert profile["consonant_onset_source"] == profile["consonant_onset_target"]
+    assert profile["consonant_coda_source"] == profile["consonant_coda_target"]
+
+
+def test_slant_rhyme_requires_shared_vowel_and_varied_consonants():
+    analyzer = EnhancedPhoneticAnalyzer()
+
+    profile = analyzer.derive_rhyme_profile("money", "lusty")
+
+    assert profile["rhyme_type"] == "slant"
+    assert profile["last_vowel_sound_source"] == profile["last_vowel_sound_target"]
+    differs = (
+        profile["consonant_onset_source"] != profile["consonant_onset_target"]
+        or profile["consonant_coda_source"] != profile["consonant_coda_target"]
+    )
+    assert differs, "Expected consonant context to differ for slant rhymes"


### PR DESCRIPTION
## Summary
- enhance the phonetic analyzer to capture final vowel and consonant context so slant rhymes share vowels but differ in consonants
- expose richer metadata and resolved rhyme types through `RhymeFeatureProfile` and analyzer APIs used by the search service
- add regression tests covering the new rhyme classification behaviour for perfect and slant matches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6e6e52ae483229f7b04b81ff96d53