### PR TITLE
Restore multi-word rhymes, stress metadata, and rap context

### DIFF
--- a/rhyme_rarity/app/ui/gradio.py
+++ b/rhyme_rarity/app/ui/gradio.py
@@ -95,6 +95,7 @@ def create_interface(
     .rr-rhyme-line {display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline;}
     .rr-rhyme-term {font-weight: 700; letter-spacing: 0.04em; color: #0f172a;}
     .rr-rhyme-details-inline {color: #475569; font-size: 0.95rem;}
+    .rr-rhyme-context {margin-top: 6px; color: #1e293b; font-size: 0.92rem; line-height: 1.35;}
     .rr-empty {margin: 0; color: #94a3b8; font-style: italic;}
     .rr-accordion .gr-accordion-label {font-weight: 600;}
     """


### PR DESCRIPTION
## Summary
- ensure multi-word rhyme candidates are always collected and deduplicated before splitting perfect and slant buckets
- expose stress patterns from entry-level metadata and filter placeholder values so every rendered rhyme shows a useful pattern
- display lyrical context in the rap database results with supporting styles for the new context block

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6ec0382448322acf2c6a74bfe46bd