### PR TITLE
Add metrical foot labels to stress pattern display

### DIFF
--- a/rhyme_rarity/app/services/search_service.py
+++ b/rhyme_rarity/app/services/search_service.py
@@ -2393,6 +2393,32 @@ class RhymeQueryOrchestrator:
 class RhymeResultFormatter:
     """Format rhyme search results into a rich markdown summary."""
 
+    @staticmethod
+    def _stress_pattern_label(pattern: str) -> Optional[str]:
+        """Return a metrical foot label for a normalized stress pattern."""
+
+        if not pattern:
+            return None
+
+        normalized = re.sub(r"[^0-2]", "", pattern)
+        if not normalized:
+            return None
+
+        normalized = normalized.replace("2", "1")
+        foot_map = [
+            ("100", "Dactyl"),
+            ("001", "Anapest"),
+            ("10", "Trochee"),
+            ("01", "Iamb"),
+            ("11", "Spondee"),
+        ]
+
+        for prefix, label in foot_map:
+            if normalized.startswith(prefix):
+                return label
+
+        return None
+
     def format_rhyme_results(self, source_word: str, rhymes: Dict[str, Any]) -> str:
         """Render grouped rhyme results with shared phonetic context."""
 
@@ -2449,6 +2475,9 @@ class RhymeResultFormatter:
             if stress_pattern:
                 stress_text = str(stress_pattern).strip()
                 if stress_text and stress_text not in {"?", "??"}:
+                    label = self._stress_pattern_label(stress_text)
+                    if label:
+                        stress_text = f"{stress_text} ({label})"
                     details.append(f"Stress Pattern: {stress_text}")
 
             return details

--- a/tests/test_search_service_telemetry.py
+++ b/tests/test_search_service_telemetry.py
@@ -378,3 +378,20 @@ def test_formatter_emits_cadence_and_stress_diagnostics() -> None:
     assert "Cadence focus: Smooth Flow" in output
     assert "Min stress alignment: 0.72" in output
     assert "Phonetic threshold: 0.86" in output
+    assert "Stress Pattern: 1-0 (Trochee)" in output
+
+
+@pytest.mark.parametrize(
+    "pattern,label",
+    [
+        ("1-0", "Trochee"),
+        ("0-1", "Iamb"),
+        ("1-0-0", "Dactyl"),
+        ("0-0-1", "Anapest"),
+        ("1-1", "Spondee"),
+        ("2-0", "Trochee"),
+    ],
+)
+def test_formatter_labels_common_feet(pattern: str, label: str) -> None:
+    formatter = RhymeResultFormatter()
+    assert formatter._stress_pattern_label(pattern) == label


### PR DESCRIPTION
## Summary
- add a helper in the result formatter to derive metrical foot names from stress patterns and append them to the rendered details
- extend telemetry formatter tests to assert the annotated stress display and cover common stress pattern mappings

## Testing
- pytest tests/test_search_service_telemetry.py::test_formatter_emits_cadence_and_stress_diagnostics tests/test_search_service_telemetry.py::test_formatter_labels_common_feet

------
https://chatgpt.com/codex/tasks/task_e_68dd5ec6e2c88322b89a666d73e6bc57