### PR TITLE
Add slant strength controls and rationale to rhyme search

### DIFF
--- a/docs/search_service_pipeline.md
+++ b/docs/search_service_pipeline.md
@@ -20,6 +20,7 @@ Result normalization & return
 ## 1. Normalization & Input Preparation
 * Trim, lowercase, and validate the source word while capturing telemetry of raw inputs and limits.
 * Coerce confidence to a float, normalise filter labels (cultural, genre, rhyme type, cadence, Bradley devices), and clamp numeric thresholds for syllables, rarity, stress, and concurrency filters.【F:rhyme_rarity/app/services/search_service.py†L452-L558】
+* Capture the caller-provided `slant_strength`, forward it to telemetry, and carry the value through the internal request envelope before clamping to the supported 0–1 range downstream.【F:rhyme_rarity/app/services/search_service.py†L555-L607】【F:rhyme_rarity/app/services/search_service.py†L2430-L2475】
 * Resolve which result sources to include, detect whether any filters are active, and fetch shared collaborators: the `EnhancedPhoneticAnalyzer`, optional cultural engine, and CMU loader reference used throughout the remainder of the search.【F:rhyme_rarity/app/services/search_service.py†L526-L568】
 * Decompose the phrase, then build a rich phonetic profile of individual words by reusing the analyzer’s descriptive APIs for pronunciations, stress, syllable counts, and anchor metadata.【F:rhyme_rarity/app/services/search_service.py†L567-L652】
 
@@ -27,6 +28,7 @@ Result normalization & return
 * Derive rhyme signatures via the cultural engine when available, fall back to CMU rhyme parts, and finally fall back to the spelling-based signature cache, guaranteeing a baseline signature set.【F:rhyme_rarity/app/services/search_service.py†L725-L747】
 * Query cached CMU rhyme candidates and compute a dynamic reference similarity threshold; supplement these with repository hints by reusing the analyzer to score candidate similarities.【F:rhyme_rarity/app/services/search_service.py†L749-L799】
 * Assemble a detailed phonetic profile for the source phrase, accumulate phonetic matches, and enrich each candidate via analyzer and cultural engine callbacks before caching delivered words for downstream stages.【F:rhyme_rarity/app/services/search_service.py†L808-L1078】
+* Apply the slant-strength gate to single-word phonetic matches, using `passes_gate` for the strict setting and proportional floors for relaxed strengths, while recording which end words survive for later stages.【F:rhyme_rarity/app/services/search_service.py†L1882-L1934】【F:rhyme_rarity/app/services/search_service.py†L2520-L2538】
 * Harvest rare phonetic seeds only when the Anti-LLM branch is requested, capturing rarity, combined scores, and signature payloads for use as Module 1 seeds. This avoids redundant work when the Anti-LLM engine is disabled.【F:rhyme_rarity/app/services/search_service.py†L1080-L1141】
 
 ## 3. Cultural Repository Enrichment
@@ -36,10 +38,12 @@ Result normalization & return
 
 ## 4. Anti-LLM Pattern Generation
 * Invoke the Anti-LLM engine with harvested Module 1 seeds, aggregated rhyme signatures, and already-delivered words to discourage duplicates.【F:rhyme_rarity/app/services/search_service.py†L1403-L1416】
+* Respect the slant-strength gate when selecting Module 1 seeds—only allowing words that cleared the single-word filter when gating is active—before passing them into the generator.【F:rhyme_rarity/app/services/search_service.py†L1944-L1957】【F:rhyme_rarity/app/services/search_service.py†L2524-L2529】
 * For each generated pattern, carry forward shared phonetic context, prosody metadata, and analyzer-derived phonetics while sanitising feature profiles and enforcing confidence thresholds.【F:rhyme_rarity/app/services/search_service.py†L1417-L1471】
 
 ## 5. Result Normalisation & Output
 * Downstream helpers ensure minimum confidence, fill in feature profiles, derive rhyme categories/rhythm scores, and apply all user filters across phonetic, cultural, and anti-LLM branches before sorting and truncating the result lists.【F:rhyme_rarity/app/services/search_service.py†L1473-L1937】
+* Filter multi-word and anti-LLM candidates against the gated end-word set when applicable, surface diagnostic metadata about the enforced gate, and expose the surviving tiers back to the caller.【F:rhyme_rarity/app/services/search_service.py†L1960-L2060】【F:rhyme_rarity/app/services/search_service.py†L2300-L2356】
 
 ## Shared Collaborator Reuse
 * `EnhancedPhoneticAnalyzer` powers pronunciation descriptions, phonetic similarity checks, rarity scoring, syllable estimation, and Module 1 seed enrichment across multiple branches.【F:rhyme_rarity/app/services/search_service.py†L590-L651】【F:rhyme_rarity/app/services/search_service.py†L778-L1118】【F:rhyme_rarity/app/services/search_service.py†L1417-L1471】

--- a/rhyme_rarity/app/ui/gradio.py
+++ b/rhyme_rarity/app/ui/gradio.py
@@ -30,6 +30,7 @@ def create_interface(
         word: str,
         max_results: int,
         min_conf: float,
+        slant_strength: float,
         cultural_filter: Sequence[str] | None,
         genre_filter: Sequence[str] | None,
         rhyme_type_filter: Sequence[str] | None,
@@ -44,6 +45,7 @@ def create_interface(
             cultural_significance=_ensure_list(cultural_filter),
             genres=_ensure_list(genre_filter),
             allowed_rhyme_types=_ensure_list(rhyme_type_filter),
+            slant_strength=slant_strength,
         )
         return search_service.format_rhyme_results(word, rhymes)
 
@@ -95,6 +97,8 @@ def create_interface(
     .rr-rhyme-line {display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline;}
     .rr-rhyme-term {font-weight: 700; letter-spacing: 0.04em; color: #0f172a;}
     .rr-rhyme-details-inline {color: #475569; font-size: 0.95rem;}
+    .rr-rhyme-tier {margin-top: 6px; font-size: 0.88rem; font-weight: 600; color: #1f2937; letter-spacing: 0.01em;}
+    .rr-rhyme-rationale {margin-top: 4px; color: #475569; font-size: 0.85rem;}
     .rr-rhyme-context {margin-top: 6px; color: #1e293b; font-size: 0.92rem; line-height: 1.35;}
     .rr-empty {margin: 0; color: #94a3b8; font-style: italic;}
     .rr-accordion .gr-accordion-label {font-weight: 600;}
@@ -146,6 +150,18 @@ def create_interface(
                                 value=0.7,
                                 step=0.05,
                                 label="Min Confidence",
+                            )
+
+                            slant_strength = gr.Slider(
+                                minimum=0.0,
+                                maximum=1.0,
+                                value=1.0,
+                                step=0.05,
+                                label="Slant Strength",
+                                info=(
+                                    "1.0 favours the tightest matches; lower values admit looser"
+                                    " slant pairs."
+                                ),
                             )
 
                         with gr.Row():
@@ -200,6 +216,7 @@ def create_interface(
                 word_input,
                 max_results,
                 min_confidence,
+                slant_strength,
                 cultural_dropdown,
                 genre_dropdown,
                 rhyme_type_dropdown,
@@ -213,6 +230,7 @@ def create_interface(
                 word_input,
                 max_results,
                 min_confidence,
+                slant_strength,
                 cultural_dropdown,
                 genre_dropdown,
                 rhyme_type_dropdown,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -83,6 +83,8 @@ def _render_styles() -> None:
     .rr-rhyme-line {display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline;}
     .rr-rhyme-term {font-weight: 700; letter-spacing: 0.04em; color: #0f172a;}
     .rr-rhyme-details-inline {color: #475569; font-size: 0.95rem;}
+    .rr-rhyme-tier {margin-top: 6px; font-size: 0.88rem; font-weight: 600; color: #1f2937; letter-spacing: 0.01em;}
+    .rr-rhyme-rationale {margin-top: 4px; color: #475569; font-size: 0.85rem;}
     .rr-rhyme-context {margin-top: 6px; color: #1e293b; font-size: 0.92rem; line-height: 1.35;}
     .rr-empty {margin: 0; color: #94a3b8; font-style: italic;}
     </style>
@@ -124,7 +126,7 @@ def main() -> None:
             "Word to find rhymes for",
             help="Enter the word you want to rhyme (e.g., love, flow, money).",
         )
-        col1, col2 = st.columns(2)
+        col1, col2, col3 = st.columns(3)
         with col1:
             max_results = st.slider(
                 "Max results",
@@ -140,6 +142,18 @@ def main() -> None:
                 max_value=1.0,
                 value=0.7,
                 step=0.05,
+            )
+        with col3:
+            slant_strength = st.slider(
+                "Slant strength",
+                min_value=0.0,
+                max_value=1.0,
+                value=1.0,
+                step=0.05,
+                help=(
+                    "Raise to insist on tighter rime/vowel/coda alignment; lower to"
+                    " allow looser slant matches."
+                ),
             )
 
         col3, col4, col5 = st.columns(3)
@@ -179,6 +193,7 @@ def main() -> None:
                 cultural_significance=list(cultural_filter),
                 genres=list(genre_filter),
                 allowed_rhyme_types=list(rhyme_type_filter),
+                slant_strength=slant_strength,
             )
             formatted = search_service.format_rhyme_results(word, rhymes)
 


### PR DESCRIPTION
## Summary
- add a slant strength slider to both the Streamlit and Gradio UIs and forward the value to the backend search
- gate phonetic matches with the adjustable slant strength, reuse the gate for multi-word/anti-LLM generation, and expose the resulting end-word set in filters
- surface each result's slant tier with rime/vowel/coda/stress rationale plus diagnostics for the current slant gate

## Testing
- pytest tests/test_search_service_input_validation.py
- pytest tests/test_search_service_filters.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7053169c8322a87fa508cb84d26f