### PR TITLE
Refactor phrase templates to load from data configuration

### DIFF
--- a/rhyme_rarity/core/phrase_corpus.py
+++ b/rhyme_rarity/core/phrase_corpus.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
-from typing import Dict, Iterable, Sequence, Set
+from functools import lru_cache
+from importlib import resources
+from typing import Dict, Iterable, Mapping, Sequence, Set
 
 __all__ = [
     "lookup_template_words",
@@ -27,37 +31,192 @@ def _normalize_rhyme_key(key: str) -> str:
     return cleaned.upper()
 
 
-# Template banks organised by simplified rhyme key. The goal is to provide a
-# small but expressive set of modifiers that can be combined with rhyming
-# terminal words. We blend these targeted inventories with a generic fallback so
-# every rhyme key can generate at least a handful of phrase variants.
-PHONETIC_TEMPLATE_BANK: Dict[str, Dict[str, Sequence[str]]] = {
-    "EY L": {
-        "adjectives": ("paper", "blazing", "ancient", "wandering"),
-        "nouns": ("ghost", "river", "shadow"),
-        "verbs": ("blaze", "forge", "chase"),
-    },
-    "EY": {
-        "adjectives": ("everyday", "wayward"),
-        "nouns": ("sunset", "morning"),
-        "verbs": ("sway", "play"),
-    },
-    "OW": {
-        "adjectives": ("steady", "afterglow", "hollow"),
-        "nouns": ("evening", "river"),
-        "verbs": ("follow", "borrow", "let"),
-    },
-    "IY L": {
-        "adjectives": ("steel", "eager", "emerald"),
-        "nouns": ("city", "winter"),
-        "verbs": ("feel", "reel", "conceal"),
-    },
-    "AY T": {
-        "adjectives": ("midnight", "satellite"),
-        "nouns": ("candle", "street"),
-        "verbs": ("ignite", "rewrite"),
-    },
+_TEMPLATE_CONFIG_ENV = "RHYME_RARITY_TEMPLATE_CONFIG"
+
+_VOWEL_PHONEMES = {
+    "AA",
+    "AE",
+    "AH",
+    "AO",
+    "AW",
+    "AY",
+    "EH",
+    "ER",
+    "EY",
+    "IH",
+    "IY",
+    "OW",
+    "OY",
+    "UH",
+    "UW",
 }
+
+
+@lru_cache()
+def _load_template_bank() -> tuple[
+    Dict[str, Dict[str, Sequence[str]]],
+    Dict[str, Dict[str, Sequence[str]]],
+]:
+    """Load template configuration from disk.
+
+    Returns:
+        A tuple of ``(templates, fallback_stems)`` where ``templates`` maps a
+        full rhyme key to slot inventories and ``fallback_stems`` maps vowel
+        families to base words that can be inflected when an exact match is not
+        present.
+    """
+
+    path = os.getenv(_TEMPLATE_CONFIG_ENV)
+    raw_config: Mapping[str, object] | None = None
+
+    if path:
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                raw_config = json.load(handle)
+        except FileNotFoundError:
+            raw_config = None
+    if raw_config is None:
+        try:
+            config_path = resources.files("rhyme_rarity").joinpath(
+                "data", "phonetic_templates.json"
+            )
+            with config_path.open("r", encoding="utf-8") as handle:
+                raw_config = json.load(handle)
+        except FileNotFoundError:
+            raw_config = {}
+
+    if not isinstance(raw_config, Mapping):
+        return {}, {}
+
+    templates: Dict[str, Dict[str, Sequence[str]]] = {}
+    templates_section = raw_config.get("templates")
+    if isinstance(templates_section, Mapping):
+        for raw_key, slots in templates_section.items():
+            normalized_key = _normalize_rhyme_key(str(raw_key))
+            if not normalized_key or not isinstance(slots, Mapping):
+                continue
+            normalized_slots: Dict[str, Sequence[str]] = {}
+            for slot, words in slots.items():
+                if not isinstance(words, Sequence) or isinstance(words, (str, bytes)):
+                    continue
+                cleaned = tuple(
+                    word.strip()
+                    for word in words
+                    if isinstance(word, str) and word.strip()
+                )
+                if cleaned:
+                    normalized_slots[str(slot)] = cleaned
+            if normalized_slots:
+                templates[normalized_key] = normalized_slots
+
+    fallback: Dict[str, Dict[str, Sequence[str]]] = {}
+    fallback_section = raw_config.get("fallback_stems")
+    if isinstance(fallback_section, Mapping):
+        for vowel, slots in fallback_section.items():
+            normalized_vowel = _normalize_rhyme_key(str(vowel))
+            if not normalized_vowel or not isinstance(slots, Mapping):
+                continue
+            normalized_slots = {}
+            for slot, words in slots.items():
+                if not isinstance(words, Sequence) or isinstance(words, (str, bytes)):
+                    continue
+                cleaned = tuple(
+                    word.strip()
+                    for word in words
+                    if isinstance(word, str) and word.strip()
+                )
+                if cleaned:
+                    normalized_slots[str(slot)] = cleaned
+            if normalized_slots:
+                fallback[normalized_vowel] = normalized_slots
+
+    return templates, fallback
+
+
+_CONSONANT_DOUBLE_PATTERN = re.compile(r"[aeiou][bcdfghjklmnpqrtvz]$")
+
+
+def _extract_primary_vowel(key: str) -> str:
+    """Return the most specific vowel symbol contained in ``key``."""
+
+    if not key:
+        return ""
+    tokens = key.split()
+    for token in tokens:
+        if token in _VOWEL_PHONEMES:
+            return token
+    return tokens[0] if tokens else ""
+
+
+def _derive_verb_variants(stem: str) -> Set[str]:
+    """Generate light-weight inflections for ``stem`` verbs."""
+
+    lower = stem.lower()
+    variants: Set[str] = set()
+    if not lower:
+        return variants
+
+    variants.add(stem + "s")
+    if lower.endswith("e") and not lower.endswith(("ee", "oe")):
+        variants.add(stem + "d")
+        variants.add(stem[:-1] + "ing")
+    else:
+        if len(lower) <= 4 and _CONSONANT_DOUBLE_PATTERN.search(lower):
+            doubled = stem + stem[-1]
+            variants.add(doubled + "ed")
+            variants.add(doubled + "ing")
+        else:
+            variants.add(stem + "ed")
+            variants.add(stem + "ing")
+    return variants
+
+
+def _derive_noun_variants(noun: str) -> Set[str]:
+    """Return a set of pluralised noun forms."""
+
+    lower = noun.lower()
+    variants: Set[str] = set()
+    if not lower:
+        return variants
+
+    if lower.endswith("y") and not lower.endswith(("ay", "ey", "iy", "oy", "uy")):
+        variants.add(noun[:-1] + "ies")
+    elif lower.endswith(("s", "x", "z", "ch", "sh")):
+        variants.add(noun + "es")
+    else:
+        variants.add(noun + "s")
+    return variants
+
+
+def _derive_fallback_templates(
+    normalized_key: str,
+    fallback_stems: Dict[str, Dict[str, Sequence[str]]],
+) -> Dict[str, Set[str]]:
+    """Build template suggestions for keys missing from the explicit bank."""
+
+    vowel = _extract_primary_vowel(normalized_key)
+    if not vowel:
+        return {}
+
+    stems = fallback_stems.get(vowel)
+    if not stems:
+        return {}
+
+    derived: Dict[str, Set[str]] = {}
+    for slot, words in stems.items():
+        slot_values: Set[str] = set()
+        for word in words:
+            cleaned = (word or "").strip()
+            if not cleaned:
+                continue
+            slot_values.add(cleaned)
+            if slot == "verbs":
+                slot_values.update(_derive_verb_variants(cleaned))
+            elif slot == "nouns":
+                slot_values.update(_derive_noun_variants(cleaned))
+        if slot_values:
+            derived[slot] = slot_values
+    return derived
 
 GENERIC_TEMPLATE_BANK: Dict[str, Sequence[str]] = {
     "adjectives": ("silver", "hidden", "lonely", "turbulent"),
@@ -111,17 +270,27 @@ def lookup_template_words(rhyme_keys: Iterable[str]) -> Dict[str, Set[str]]:
         "verbs": set(),
     }
 
+    template_bank, fallback_stems = _load_template_bank()
+
     for key in rhyme_keys:
         normalized = _normalize_rhyme_key(key)
         if not normalized:
             continue
-        bank = PHONETIC_TEMPLATE_BANK.get(normalized)
-        if not bank:
+        bank = template_bank.get(normalized)
+        slot_words: Dict[str, Set[str]]
+        if bank:
+            slot_words = {
+                slot: {word for word in words if word}
+                for slot, words in bank.items()
+            }
+        else:
+            slot_words = _derive_fallback_templates(normalized, fallback_stems)
+        if not slot_words:
             continue
-        for slot, words in bank.items():
+        for slot, words in slot_words.items():
             if slot not in collected:
                 collected[slot] = set()
-            collected[slot].update(word for word in words if word)
+            collected[slot].update(words)
 
     # Merge generic fallbacks and ensure no slot is empty. The generics also act
     # as a mild smoothing factor so uncommon rhyme keys can still generate

--- a/rhyme_rarity/data/phonetic_templates.json
+++ b/rhyme_rarity/data/phonetic_templates.json
@@ -1,0 +1,126 @@
+{
+  "templates": {
+    "AE N": {
+      "adjectives": ["ancient", "brazen", "vagrant"],
+      "nouns": ["lantern", "ballad", "pattern"],
+      "verbs": ["gather", "wander", "chant"]
+    },
+    "ER": {
+      "adjectives": ["fervent", "inner", "weathered"],
+      "nouns": ["harbor", "ember", "murmur"],
+      "verbs": ["murmur", "shiver", "shelter"]
+    },
+    "OW N": {
+      "adjectives": ["open", "overgrown", "shadowed"],
+      "nouns": ["meadow", "window", "afterglow"],
+      "verbs": ["follow", "shadow", "glow"]
+    },
+    "IH NG": {
+      "adjectives": ["glittering", "lingering", "whispering"],
+      "nouns": ["evening", "morning", "painting"],
+      "verbs": ["linger", "whisper", "glimmer"]
+    },
+    "IY M": {
+      "adjectives": ["dreamlike", "serene", "gleaming"],
+      "nouns": ["dream", "stream", "theme"],
+      "verbs": ["gleam", "redeem", "beam"]
+    },
+    "AA R": {
+      "adjectives": ["starlit", "scarlet", "ancient"],
+      "nouns": ["guitar", "altar", "bazaar"],
+      "verbs": ["carve", "regard", "harm"]
+    },
+    "AO R": {
+      "adjectives": ["stormy", "seaborne", "sorrowful"],
+      "nouns": ["shore", "corridor", "meteor"],
+      "verbs": ["roar", "soar", "implore"]
+    },
+    "UW N": {
+      "adjectives": ["moonlit", "luminous", "cool"],
+      "nouns": ["moon", "tune", "lagoon"],
+      "verbs": ["croon", "attune", "balloon"]
+    },
+    "AY N": {
+      "adjectives": ["shining", "vivid", "untamed"],
+      "nouns": ["skyline", "guideline", "vine"],
+      "verbs": ["align", "incline", "shine"]
+    },
+    "EH L": {
+      "adjectives": ["sacred", "gentle", "melodic"],
+      "nouns": ["bell", "chapel", "carousel"],
+      "verbs": ["level", "revel", "settle"]
+    },
+    "AH M": {
+      "adjectives": ["solemn", "ancient", "even"],
+      "nouns": ["harvest", "anthem", "kingdom"],
+      "verbs": ["become", "succumb", "hum"]
+    },
+    "OY N": {
+      "adjectives": ["loyal", "buoyant", "joyful"],
+      "nouns": ["coin", "alloy", "buoy"],
+      "verbs": ["enjoy", "employ", "rejoin"]
+    }
+  },
+  "fallback_stems": {
+    "AE": {
+      "adjectives": ["ancient", "brazen", "vagrant"],
+      "nouns": ["lantern", "ballad", "pattern"],
+      "verbs": ["gather", "wander", "chant"]
+    },
+    "ER": {
+      "adjectives": ["fervent", "inner", "weathered"],
+      "nouns": ["harbor", "ember", "murmur"],
+      "verbs": ["murmur", "shiver", "shelter"]
+    },
+    "OW": {
+      "adjectives": ["open", "overgrown", "shadowed"],
+      "nouns": ["meadow", "window", "afterglow"],
+      "verbs": ["follow", "shadow", "glow"]
+    },
+    "IH": {
+      "adjectives": ["glittering", "lingering", "whispering"],
+      "nouns": ["evening", "morning", "painting"],
+      "verbs": ["linger", "whisper", "glimmer"]
+    },
+    "IY": {
+      "adjectives": ["dreamlike", "serene", "gleaming"],
+      "nouns": ["dream", "stream", "theme"],
+      "verbs": ["gleam", "redeem", "beam"]
+    },
+    "AA": {
+      "adjectives": ["starlit", "scarlet", "ancient"],
+      "nouns": ["guitar", "altar", "bazaar"],
+      "verbs": ["carve", "regard", "harm"]
+    },
+    "AO": {
+      "adjectives": ["stormy", "seaborne", "sorrowful"],
+      "nouns": ["shore", "corridor", "meteor"],
+      "verbs": ["roar", "soar", "implore"]
+    },
+    "UW": {
+      "adjectives": ["moonlit", "luminous", "cool"],
+      "nouns": ["moon", "tune", "lagoon"],
+      "verbs": ["croon", "attune", "balloon"]
+    },
+    "AY": {
+      "adjectives": ["shining", "vivid", "untamed"],
+      "nouns": ["skyline", "guideline", "vine"],
+      "verbs": ["align", "incline", "shine"]
+    },
+    "EH": {
+      "adjectives": ["sacred", "gentle", "melodic"],
+      "nouns": ["bell", "chapel", "carousel"],
+      "verbs": ["level", "revel", "settle"]
+    },
+    "AH": {
+      "adjectives": ["solemn", "ancient", "even"],
+      "nouns": ["harvest", "anthem", "kingdom"],
+      "verbs": ["become", "succumb", "hum"]
+    },
+    "OY": {
+      "adjectives": ["loyal", "buoyant", "joyful"],
+      "nouns": ["coin", "alloy", "buoy"],
+      "verbs": ["enjoy", "employ", "rejoin"]
+    }
+  }
+}

--- a/tests/test_phrase_corpus_templates.py
+++ b/tests/test_phrase_corpus_templates.py
@@ -1,0 +1,29 @@
+import pytest
+
+from rhyme_rarity.core.phrase_corpus import lookup_template_words
+
+
+@pytest.mark.parametrize(
+    "rhyme_key, expected_words",
+    [
+        ("AE N", {"lantern", "gather"}),
+        ("UW N", {"lagoon", "attune"}),
+    ],
+)
+def test_lookup_template_words_uses_extended_bank(rhyme_key, expected_words):
+    results = lookup_template_words([rhyme_key])
+    # Ensure targeted entries from the data-backed inventory appear alongside
+    # generic defaults.
+    aggregated = set().union(*results.values())
+    missing = expected_words - aggregated
+    if missing:
+        pytest.fail(f"Expected {expected_words} but missing {missing} in template results")
+
+
+def test_lookup_template_words_falls_back_to_vowel_family():
+    # The key "AE S K" is not represented directly in the JSON configuration.
+    # The lookup should fall back to the vowel family templates and emit
+    # morphological variants derived from the stored stems.
+    results = lookup_template_words(["AE S K"])
+    assert "lanterns" in results["nouns"]
+    assert {"chant", "chanting"}.issubset(results["verbs"])


### PR DESCRIPTION
## Summary
- replace the hard-coded phonetic template bank with a JSON-driven configuration covering additional rhyme keys
- add vowel-family fallback logic that derives noun and verb variants when a rhyme key lacks explicit templates
- add unit tests that exercise new rhyme keys and confirm fallback suggestions are generated

## Testing
- pytest tests/test_phrase_corpus_templates.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7e4ab8288322962844012df7130f