### PR TITLE
Expand phrase corpus and dynamic fallback

### DIFF
--- a/rhyme_rarity/data/phrase_corpus.json
+++ b/rhyme_rarity/data/phrase_corpus.json
@@ -1,0 +1,260 @@
+{
+  "by_word": {
+    "time": [
+      "take your time",
+      "spare the time",
+      "race against time",
+      "lost in time"
+    ],
+    "fire": [
+      "play with fire",
+      "line of fire",
+      "set on fire",
+      "open fire"
+    ],
+    "dream": [
+      "living the dream",
+      "keep the dream",
+      "pipe dream",
+      "within a dream"
+    ],
+    "mind": [
+      "peace of mind",
+      "state of mind",
+      "frame of mind",
+      "speak your mind"
+    ],
+    "heart": [
+      "change of heart",
+      "young at heart",
+      "open heart",
+      "brave heart"
+    ],
+    "star": [
+      "shooting star",
+      "guiding star",
+      "rising star",
+      "fallen star"
+    ],
+    "road": [
+      "open road",
+      "down the road",
+      "middle of the road",
+      "hit the road"
+    ],
+    "night": [
+      "dead of night",
+      "late at night",
+      "into the night",
+      "middle of the night"
+    ],
+    "light": [
+      "guiding light",
+      "midnight light",
+      "northern light",
+      "hold the light"
+    ],
+    "sky": [
+      "open sky",
+      "across the sky",
+      "painted sky",
+      "night sky"
+    ],
+    "hand": [
+      "lend a hand",
+      "sleight of hand",
+      "second hand",
+      "raise your hand"
+    ],
+    "gold": [
+      "heart of gold",
+      "fool's gold",
+      "veins of gold",
+      "fields of gold"
+    ],
+    "stone": [
+      "set in stone",
+      "written in stone",
+      "cast in stone",
+      "heart of stone"
+    ],
+    "storm": [
+      "weather the storm",
+      "ride the storm",
+      "brewing storm",
+      "perfect storm"
+    ],
+    "home": [
+      "close to home",
+      "right at home",
+      "back home",
+      "head for home"
+    ],
+    "river": [
+      "cross the river",
+      "down the river",
+      "river to river",
+      "over the river"
+    ],
+    "song": [
+      "sing the song",
+      "end of the song",
+      "write a song",
+      "love song"
+    ],
+    "wind": [
+      "ride the wind",
+      "against the wind",
+      "into the wind",
+      "catch the wind"
+    ],
+    "voice": [
+      "find your voice",
+      "raise your voice",
+      "inner voice",
+      "lost voice"
+    ],
+    "world": [
+      "around the world",
+      "whole world",
+      "world to world",
+      "world at large"
+    ]
+  },
+  "by_rhyme": {
+    "AY M": [
+      "take your time",
+      "spare the time",
+      "race against time",
+      "lost in time",
+      "back in time"
+    ],
+    "AY ER": [
+      "play with fire",
+      "line of fire",
+      "set on fire",
+      "open fire",
+      "ring of fire"
+    ],
+    "IY M": [
+      "living the dream",
+      "keep the dream",
+      "pipe dream",
+      "within a dream",
+      "beyond the dream"
+    ],
+    "AY ND": [
+      "peace of mind",
+      "state of mind",
+      "frame of mind",
+      "speak your mind",
+      "change your mind"
+    ],
+    "AA RT": [
+      "change of heart",
+      "young at heart",
+      "open heart",
+      "brave heart",
+      "heart to heart"
+    ],
+    "AA R": [
+      "shooting star",
+      "guiding star",
+      "rising star",
+      "fallen star",
+      "north star"
+    ],
+    "OW D": [
+      "open road",
+      "down the road",
+      "middle of the road",
+      "hit the road",
+      "old road"
+    ],
+    "AY T": [
+      "dead of night",
+      "late at night",
+      "into the night",
+      "middle of the night",
+      "guiding light",
+      "midnight light"
+    ],
+    "AY": [
+      "open sky",
+      "across the sky",
+      "painted sky",
+      "night sky",
+      "clear sky"
+    ],
+    "AE N D": [
+      "lend a hand",
+      "sleight of hand",
+      "second hand",
+      "raise your hand",
+      "steady hand"
+    ],
+    "OW L D": [
+      "heart of gold",
+      "fool's gold",
+      "veins of gold",
+      "fields of gold",
+      "hands of gold"
+    ],
+    "OW N": [
+      "set in stone",
+      "written in stone",
+      "cast in stone",
+      "heart of stone",
+      "cornerstone"
+    ],
+    "AO RM": [
+      "weather the storm",
+      "ride the storm",
+      "brewing storm",
+      "perfect storm",
+      "gathering storm"
+    ],
+    "OW M": [
+      "close to home",
+      "right at home",
+      "back home",
+      "head for home",
+      "call it home"
+    ],
+    "IH V ER": [
+      "cross the river",
+      "down the river",
+      "river to river",
+      "over the river",
+      "river of silver"
+    ],
+    "AO NG": [
+      "sing the song",
+      "end of the song",
+      "write a song",
+      "love song",
+      "battle song"
+    ],
+    "IH N D": [
+      "ride the wind",
+      "against the wind",
+      "into the wind",
+      "catch the wind",
+      "in the wind"
+    ],
+    "OY S": [
+      "find your voice",
+      "raise your voice",
+      "inner voice",
+      "lost voice",
+      "echoing voice"
+    ],
+    "ER L D": [
+      "around the world",
+      "whole world",
+      "world to world",
+      "world at large",
+      "brave new world"
+    ]
+  }
+}

--- a/tests/test_phrase_corpus.py
+++ b/tests/test_phrase_corpus.py
@@ -1,0 +1,72 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rhyme_rarity.core.phrase_corpus import lookup_ngram_phrases
+
+
+@pytest.mark.parametrize("word", ["time", "fire", "dream", "mind", "heart"])
+def test_lookup_ngram_phrases_returns_general_phrases(word: str) -> None:
+    """Ensure common vocabulary pulls idiomatic phrases from the corpus."""
+
+    phrases = lookup_ngram_phrases(word, ())
+    assert phrases, f"Expected idioms for {word}"
+    assert any(phrase.lower().split()[-1] == word for phrase in phrases)
+
+
+def test_lookup_ngram_phrases_dynamic_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the corpus lacks a word the database fallback should supply phrases."""
+
+    db_path = tmp_path / "patterns.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE song_rhyme_patterns (
+                target_word TEXT,
+                target_word_normalized TEXT,
+                target_context TEXT,
+                lyrical_context TEXT,
+                confidence_score REAL,
+                phonetic_similarity REAL,
+                pattern TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO song_rhyme_patterns (
+                target_word,
+                target_word_normalized,
+                target_context,
+                lyrical_context,
+                confidence_score,
+                phonetic_similarity,
+                pattern
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "embers",
+                "embers",
+                "glow like embers",
+                "shadows glow like embers",
+                0.9,
+                0.8,
+                "embers / members",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    monkeypatch.setenv("RHYME_RARITY_PHRASE_DB", str(db_path))
+
+    no_dynamic = lookup_ngram_phrases("embers", (), enable_dynamic_fallback=False)
+    assert no_dynamic == set()
+
+    phrases = lookup_ngram_phrases("embers", ())
+    normalized = {phrase.lower() for phrase in phrases}
+    assert "glow like embers" in normalized
+    assert all(phrase.split()[-1] == "embers" for phrase in normalized)


### PR DESCRIPTION
## Summary
- externalize the n-gram corpus into a JSON dataset and load it lazily at runtime
- enhance `lookup_ngram_phrases` with optional dynamic SQLite fallbacks when the corpus lacks a match
- add tests validating common vocabulary lookups and database mining behaviour

## Testing
- pytest tests/test_phrase_corpus.py

------
https://chatgpt.com/codex/tasks/task_e_68dd812a11cc832290bcab7ea6da1531