### PR TITLE
Support phonetic key lookups for cultural rhyme queries

### DIFF
--- a/rhyme_rarity/core/analyzer.py
+++ b/rhyme_rarity/core/analyzer.py
@@ -1323,6 +1323,20 @@ class PhraseRimeKeyInfo:
     compound_strings: Tuple[str, ...]
 
 
+def normalize_rime_key(value: Optional[str]) -> Optional[str]:
+    """Return a canonical representation for rime key comparisons."""
+
+    text = str(value or "").strip()
+    if not text:
+        return None
+
+    tokens = [segment.strip().upper() for segment in text.split() if segment.strip()]
+    if not tokens:
+        return None
+
+    return " ".join(tokens)
+
+
 def collect_rhyme_parts(word: str, loader: Optional[CMUDictLoader]) -> Set[str]:
     """Return CMU rhyme parts for ``word`` with a pronouncing fallback."""
 


### PR DESCRIPTION
## Summary
- extend the SQLite rhyme schema with rime key columns, populate them via CMU analysis, and index the new fields
- thread analyzer-derived phonetic keys through the search and cultural matching pipeline so multi-word inputs can hit stored phrases
- add database integration coverage proving multi-word requests return both phrase and single-word matches via phonetic keys

## Testing
- pytest tests/test_database_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68dd894d38f083229b3334f81dc03ea4