### PR TITLE
Fix phrase corpus loading fallback and add regression test

### DIFF
--- a/tests/test_phrase_workflows.py
+++ b/tests/test_phrase_workflows.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
@@ -10,6 +11,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from rhyme_rarity.app.services.search_service import RhymeQueryOrchestrator
 from rhyme_rarity.core import EnhancedPhoneticAnalyzer, passes_gate, score_pair
+from rhyme_rarity.core import phrase_corpus
 from rhyme_rarity.core.phrases import (
     generate_phrases_for_endwords,
     rank_phrases,
@@ -30,10 +32,20 @@ def test_generate_phrases_end_with_permitted_tokens() -> None:
 
 
 def test_retrieve_phrases_by_last_word_returns_idioms() -> None:
-    results = retrieve_phrases_by_last_word("window", rhyme_keys=("OW",))
+    phrase_corpus._load_ngram_corpus.cache_clear()
+    try:
+        with patch.object(phrase_corpus.resources, "files", side_effect=FileNotFoundError):
+            with patch.object(
+                phrase_corpus, "_mine_phrases_from_database", side_effect=AssertionError
+            ) as mined:
+                results = retrieve_phrases_by_last_word("window", rhyme_keys=("OW",))
+    finally:
+        phrase_corpus._load_ngram_corpus.cache_clear()
 
     phrases = {phrase for phrase, _ in results}
     assert "open window" in phrases
+
+    mined.assert_not_called()
 
     for phrase, metadata in results:
         if phrase == "open window":


### PR DESCRIPTION
## Summary
- add a filesystem fallback when loading the phrase corpus JSON asset
- ensure idiom lookup prefers the direct corpus before reaching for the database
- add a regression test that retrieves "open window" without touching the database

## Testing
- pytest tests/test_phrase_workflows.py

------
https://chatgpt.com/codex/tasks/task_e_68dde4da3b148322bcd455f7915216fa